### PR TITLE
Feature/elements api 20191210

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,4 +5,3 @@
 *.py       text eol=lf
 *.go       text eol=lf
 *.c        text eol=lf
-*.bat      text eol=crlf

--- a/cfdgo.c
+++ b/cfdgo.c
@@ -228,7 +228,7 @@ static void* Swig_malloc(int c) {
 extern "C" {
 #endif
 
-void _wrap_Swig_free_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0) {
+void _wrap_Swig_free_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0) {
   void *arg1 = (void *) 0 ;
   
   arg1 = *(void **)&_swig_go_0; 
@@ -238,7 +238,7 @@ void _wrap_Swig_free_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0) {
 }
 
 
-void *_wrap_Swig_malloc_cfdgo_6d81cf84a6c5cb9b(intgo _swig_go_0) {
+void *_wrap_Swig_malloc_cfdgo_3cf2a94eb1b532b7(intgo _swig_go_0) {
   int arg1 ;
   void *result = 0 ;
   void *_swig_go_result;
@@ -251,7 +251,7 @@ void *_wrap_Swig_malloc_cfdgo_6d81cf84a6c5cb9b(intgo _swig_go_0) {
 }
 
 
-intgo _wrap_kCfdSuccess_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdSuccess_cfdgo_3cf2a94eb1b532b7() {
   enum CfdErrorCode result;
   intgo _swig_go_result;
   
@@ -263,7 +263,7 @@ intgo _wrap_kCfdSuccess_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdUnknownError_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdUnknownError_cfdgo_3cf2a94eb1b532b7() {
   enum CfdErrorCode result;
   intgo _swig_go_result;
   
@@ -275,7 +275,7 @@ intgo _wrap_kCfdUnknownError_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdInternalError_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdInternalError_cfdgo_3cf2a94eb1b532b7() {
   enum CfdErrorCode result;
   intgo _swig_go_result;
   
@@ -287,7 +287,7 @@ intgo _wrap_kCfdInternalError_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdMemoryFullError_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdMemoryFullError_cfdgo_3cf2a94eb1b532b7() {
   enum CfdErrorCode result;
   intgo _swig_go_result;
   
@@ -299,7 +299,7 @@ intgo _wrap_kCfdMemoryFullError_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdIllegalArgumentError_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdIllegalArgumentError_cfdgo_3cf2a94eb1b532b7() {
   enum CfdErrorCode result;
   intgo _swig_go_result;
   
@@ -311,7 +311,7 @@ intgo _wrap_kCfdIllegalArgumentError_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdIllegalStateError_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdIllegalStateError_cfdgo_3cf2a94eb1b532b7() {
   enum CfdErrorCode result;
   intgo _swig_go_result;
   
@@ -323,7 +323,7 @@ intgo _wrap_kCfdIllegalStateError_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdOutOfRangeError_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdOutOfRangeError_cfdgo_3cf2a94eb1b532b7() {
   enum CfdErrorCode result;
   intgo _swig_go_result;
   
@@ -335,7 +335,7 @@ intgo _wrap_kCfdOutOfRangeError_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdInvalidSettingError_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdInvalidSettingError_cfdgo_3cf2a94eb1b532b7() {
   enum CfdErrorCode result;
   intgo _swig_go_result;
   
@@ -347,7 +347,7 @@ intgo _wrap_kCfdInvalidSettingError_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdConnectionError_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdConnectionError_cfdgo_3cf2a94eb1b532b7() {
   enum CfdErrorCode result;
   intgo _swig_go_result;
   
@@ -359,7 +359,7 @@ intgo _wrap_kCfdConnectionError_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdDiskAccessError_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdDiskAccessError_cfdgo_3cf2a94eb1b532b7() {
   enum CfdErrorCode result;
   intgo _swig_go_result;
   
@@ -371,7 +371,7 @@ intgo _wrap_kCfdDiskAccessError_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdEnableBitcoin_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdEnableBitcoin_cfdgo_3cf2a94eb1b532b7() {
   enum CfdLibraryFunction result;
   intgo _swig_go_result;
   
@@ -383,7 +383,7 @@ intgo _wrap_kCfdEnableBitcoin_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdEnableElements_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdEnableElements_cfdgo_3cf2a94eb1b532b7() {
   enum CfdLibraryFunction result;
   intgo _swig_go_result;
   
@@ -395,7 +395,7 @@ intgo _wrap_kCfdEnableElements_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_CfdGetSupportedFunction_cfdgo_6d81cf84a6c5cb9b(uint64_t *_swig_go_0) {
+intgo _wrap_CfdGetSupportedFunction_cfdgo_3cf2a94eb1b532b7(uint64_t *_swig_go_0) {
   uint64_t *arg1 = (uint64_t *) 0 ;
   int result;
   intgo _swig_go_result;
@@ -408,7 +408,7 @@ intgo _wrap_CfdGetSupportedFunction_cfdgo_6d81cf84a6c5cb9b(uint64_t *_swig_go_0)
 }
 
 
-intgo _wrap_CfdInitialize_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_CfdInitialize_cfdgo_3cf2a94eb1b532b7() {
   int result;
   intgo _swig_go_result;
   
@@ -419,7 +419,7 @@ intgo _wrap_CfdInitialize_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_CfdFinalize_cfdgo_6d81cf84a6c5cb9b(bool _swig_go_0) {
+intgo _wrap_CfdFinalize_cfdgo_3cf2a94eb1b532b7(bool _swig_go_0) {
   bool arg1 ;
   int result;
   intgo _swig_go_result;
@@ -432,7 +432,7 @@ intgo _wrap_CfdFinalize_cfdgo_6d81cf84a6c5cb9b(bool _swig_go_0) {
 }
 
 
-intgo _wrap_CfdCreateHandle_cfdgo_6d81cf84a6c5cb9b(void **_swig_go_0) {
+intgo _wrap_CfdCreateHandle_cfdgo_3cf2a94eb1b532b7(void **_swig_go_0) {
   void **arg1 = (void **) 0 ;
   int result;
   intgo _swig_go_result;
@@ -445,7 +445,7 @@ intgo _wrap_CfdCreateHandle_cfdgo_6d81cf84a6c5cb9b(void **_swig_go_0) {
 }
 
 
-intgo _wrap_CfdCreateSimpleHandle_cfdgo_6d81cf84a6c5cb9b(void **_swig_go_0) {
+intgo _wrap_CfdCreateSimpleHandle_cfdgo_3cf2a94eb1b532b7(void **_swig_go_0) {
   void **arg1 = (void **) 0 ;
   int result;
   intgo _swig_go_result;
@@ -458,7 +458,7 @@ intgo _wrap_CfdCreateSimpleHandle_cfdgo_6d81cf84a6c5cb9b(void **_swig_go_0) {
 }
 
 
-intgo _wrap_CfdFreeHandle_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0) {
+intgo _wrap_CfdFreeHandle_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0) {
   void *arg1 = (void *) 0 ;
   int result;
   intgo _swig_go_result;
@@ -471,7 +471,7 @@ intgo _wrap_CfdFreeHandle_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0) {
 }
 
 
-intgo _wrap_CfdFreeBuffer_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0) {
+intgo _wrap_CfdFreeBuffer_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0) {
   void *arg1 = (void *) 0 ;
   int result;
   intgo _swig_go_result;
@@ -484,7 +484,7 @@ intgo _wrap_CfdFreeBuffer_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0) {
 }
 
 
-intgo _wrap_CfdGetLastErrorCode_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0) {
+intgo _wrap_CfdGetLastErrorCode_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0) {
   void *arg1 = (void *) 0 ;
   int result;
   intgo _swig_go_result;
@@ -497,7 +497,7 @@ intgo _wrap_CfdGetLastErrorCode_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0) {
 }
 
 
-intgo _wrap_CfdGetLastErrorMessage_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_* _swig_go_1) {
+intgo _wrap_CfdGetLastErrorMessage_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_* _swig_go_1) {
   void *arg1 = (void *) 0 ;
   char **arg2 = (char **) 0 ;
   int result;
@@ -517,7 +517,7 @@ intgo _wrap_CfdGetLastErrorMessage_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gos
 }
 
 
-intgo _wrap_kCfdNetworkMainnet_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdNetworkMainnet_cfdgo_3cf2a94eb1b532b7() {
   enum CfdNetworkType result;
   intgo _swig_go_result;
   
@@ -529,7 +529,7 @@ intgo _wrap_kCfdNetworkMainnet_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdNetworkTestnet_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdNetworkTestnet_cfdgo_3cf2a94eb1b532b7() {
   enum CfdNetworkType result;
   intgo _swig_go_result;
   
@@ -541,7 +541,7 @@ intgo _wrap_kCfdNetworkTestnet_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdNetworkRegtest_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdNetworkRegtest_cfdgo_3cf2a94eb1b532b7() {
   enum CfdNetworkType result;
   intgo _swig_go_result;
   
@@ -553,7 +553,7 @@ intgo _wrap_kCfdNetworkRegtest_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdNetworkLiquidv1_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdNetworkLiquidv1_cfdgo_3cf2a94eb1b532b7() {
   enum CfdNetworkType result;
   intgo _swig_go_result;
   
@@ -565,7 +565,7 @@ intgo _wrap_kCfdNetworkLiquidv1_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdNetworkElementsRegtest_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdNetworkElementsRegtest_cfdgo_3cf2a94eb1b532b7() {
   enum CfdNetworkType result;
   intgo _swig_go_result;
   
@@ -577,7 +577,7 @@ intgo _wrap_kCfdNetworkElementsRegtest_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdNetworkCustomChain_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdNetworkCustomChain_cfdgo_3cf2a94eb1b532b7() {
   enum CfdNetworkType result;
   intgo _swig_go_result;
   
@@ -589,7 +589,7 @@ intgo _wrap_kCfdNetworkCustomChain_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdP2shAddress_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdP2shAddress_cfdgo_3cf2a94eb1b532b7() {
   enum CfdAddressType result;
   intgo _swig_go_result;
   
@@ -601,7 +601,7 @@ intgo _wrap_kCfdP2shAddress_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdP2pkhAddress_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdP2pkhAddress_cfdgo_3cf2a94eb1b532b7() {
   enum CfdAddressType result;
   intgo _swig_go_result;
   
@@ -613,7 +613,7 @@ intgo _wrap_kCfdP2pkhAddress_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdP2wshAddress_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdP2wshAddress_cfdgo_3cf2a94eb1b532b7() {
   enum CfdAddressType result;
   intgo _swig_go_result;
   
@@ -625,7 +625,7 @@ intgo _wrap_kCfdP2wshAddress_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdP2wpkhAddress_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdP2wpkhAddress_cfdgo_3cf2a94eb1b532b7() {
   enum CfdAddressType result;
   intgo _swig_go_result;
   
@@ -637,7 +637,7 @@ intgo _wrap_kCfdP2wpkhAddress_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdP2shP2wshAddress_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdP2shP2wshAddress_cfdgo_3cf2a94eb1b532b7() {
   enum CfdAddressType result;
   intgo _swig_go_result;
   
@@ -649,7 +649,7 @@ intgo _wrap_kCfdP2shP2wshAddress_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdP2shP2wpkhAddress_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdP2shP2wpkhAddress_cfdgo_3cf2a94eb1b532b7() {
   enum CfdAddressType result;
   intgo _swig_go_result;
   
@@ -661,7 +661,7 @@ intgo _wrap_kCfdP2shP2wpkhAddress_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdP2sh_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdP2sh_cfdgo_3cf2a94eb1b532b7() {
   enum CfdHashType result;
   intgo _swig_go_result;
   
@@ -673,7 +673,7 @@ intgo _wrap_kCfdP2sh_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdP2pkh_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdP2pkh_cfdgo_3cf2a94eb1b532b7() {
   enum CfdHashType result;
   intgo _swig_go_result;
   
@@ -685,7 +685,7 @@ intgo _wrap_kCfdP2pkh_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdP2wsh_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdP2wsh_cfdgo_3cf2a94eb1b532b7() {
   enum CfdHashType result;
   intgo _swig_go_result;
   
@@ -697,7 +697,7 @@ intgo _wrap_kCfdP2wsh_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdP2wpkh_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdP2wpkh_cfdgo_3cf2a94eb1b532b7() {
   enum CfdHashType result;
   intgo _swig_go_result;
   
@@ -709,7 +709,7 @@ intgo _wrap_kCfdP2wpkh_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdP2shP2wsh_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdP2shP2wsh_cfdgo_3cf2a94eb1b532b7() {
   enum CfdHashType result;
   intgo _swig_go_result;
   
@@ -721,7 +721,7 @@ intgo _wrap_kCfdP2shP2wsh_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdP2shP2wpkh_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdP2shP2wpkh_cfdgo_3cf2a94eb1b532b7() {
   enum CfdHashType result;
   intgo _swig_go_result;
   
@@ -733,7 +733,7 @@ intgo _wrap_kCfdP2shP2wpkh_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdSigHashAll_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdSigHashAll_cfdgo_3cf2a94eb1b532b7() {
   enum CfdSighashType result;
   intgo _swig_go_result;
   
@@ -745,7 +745,7 @@ intgo _wrap_kCfdSigHashAll_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdSigHashNone_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdSigHashNone_cfdgo_3cf2a94eb1b532b7() {
   enum CfdSighashType result;
   intgo _swig_go_result;
   
@@ -757,7 +757,7 @@ intgo _wrap_kCfdSigHashNone_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdSigHashSingle_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdSigHashSingle_cfdgo_3cf2a94eb1b532b7() {
   enum CfdSighashType result;
   intgo _swig_go_result;
   
@@ -769,7 +769,7 @@ intgo _wrap_kCfdSigHashSingle_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdDescriptorScriptNull_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdDescriptorScriptNull_cfdgo_3cf2a94eb1b532b7() {
   enum CfdDescriptorScriptType result;
   intgo _swig_go_result;
   
@@ -781,7 +781,7 @@ intgo _wrap_kCfdDescriptorScriptNull_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdDescriptorScriptSh_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdDescriptorScriptSh_cfdgo_3cf2a94eb1b532b7() {
   enum CfdDescriptorScriptType result;
   intgo _swig_go_result;
   
@@ -793,7 +793,7 @@ intgo _wrap_kCfdDescriptorScriptSh_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdDescriptorScriptWsh_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdDescriptorScriptWsh_cfdgo_3cf2a94eb1b532b7() {
   enum CfdDescriptorScriptType result;
   intgo _swig_go_result;
   
@@ -805,7 +805,7 @@ intgo _wrap_kCfdDescriptorScriptWsh_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdDescriptorScriptPk_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdDescriptorScriptPk_cfdgo_3cf2a94eb1b532b7() {
   enum CfdDescriptorScriptType result;
   intgo _swig_go_result;
   
@@ -817,7 +817,7 @@ intgo _wrap_kCfdDescriptorScriptPk_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdDescriptorScriptPkh_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdDescriptorScriptPkh_cfdgo_3cf2a94eb1b532b7() {
   enum CfdDescriptorScriptType result;
   intgo _swig_go_result;
   
@@ -829,7 +829,7 @@ intgo _wrap_kCfdDescriptorScriptPkh_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdDescriptorScriptWpkh_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdDescriptorScriptWpkh_cfdgo_3cf2a94eb1b532b7() {
   enum CfdDescriptorScriptType result;
   intgo _swig_go_result;
   
@@ -841,7 +841,7 @@ intgo _wrap_kCfdDescriptorScriptWpkh_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdDescriptorScriptCombo_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdDescriptorScriptCombo_cfdgo_3cf2a94eb1b532b7() {
   enum CfdDescriptorScriptType result;
   intgo _swig_go_result;
   
@@ -853,7 +853,7 @@ intgo _wrap_kCfdDescriptorScriptCombo_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdDescriptorScriptMulti_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdDescriptorScriptMulti_cfdgo_3cf2a94eb1b532b7() {
   enum CfdDescriptorScriptType result;
   intgo _swig_go_result;
   
@@ -865,7 +865,7 @@ intgo _wrap_kCfdDescriptorScriptMulti_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdDescriptorScriptSortedMulti_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdDescriptorScriptSortedMulti_cfdgo_3cf2a94eb1b532b7() {
   enum CfdDescriptorScriptType result;
   intgo _swig_go_result;
   
@@ -877,7 +877,7 @@ intgo _wrap_kCfdDescriptorScriptSortedMulti_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdDescriptorScriptAddr_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdDescriptorScriptAddr_cfdgo_3cf2a94eb1b532b7() {
   enum CfdDescriptorScriptType result;
   intgo _swig_go_result;
   
@@ -889,7 +889,7 @@ intgo _wrap_kCfdDescriptorScriptAddr_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdDescriptorScriptRaw_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdDescriptorScriptRaw_cfdgo_3cf2a94eb1b532b7() {
   enum CfdDescriptorScriptType result;
   intgo _swig_go_result;
   
@@ -901,7 +901,7 @@ intgo _wrap_kCfdDescriptorScriptRaw_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdDescriptorKeyNull_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdDescriptorKeyNull_cfdgo_3cf2a94eb1b532b7() {
   enum CfdDescriptorKeyType result;
   intgo _swig_go_result;
   
@@ -913,7 +913,7 @@ intgo _wrap_kCfdDescriptorKeyNull_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdDescriptorKeyPublic_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdDescriptorKeyPublic_cfdgo_3cf2a94eb1b532b7() {
   enum CfdDescriptorKeyType result;
   intgo _swig_go_result;
   
@@ -925,7 +925,7 @@ intgo _wrap_kCfdDescriptorKeyPublic_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdDescriptorKeyBip32_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdDescriptorKeyBip32_cfdgo_3cf2a94eb1b532b7() {
   enum CfdDescriptorKeyType result;
   intgo _swig_go_result;
   
@@ -937,7 +937,7 @@ intgo _wrap_kCfdDescriptorKeyBip32_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdDescriptorKeyBip32Priv_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdDescriptorKeyBip32Priv_cfdgo_3cf2a94eb1b532b7() {
   enum CfdDescriptorKeyType result;
   intgo _swig_go_result;
   
@@ -949,7 +949,7 @@ intgo _wrap_kCfdDescriptorKeyBip32Priv_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_CfdCreateAddress_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, intgo _swig_go_1, _gostring_ _swig_go_2, _gostring_ _swig_go_3, intgo _swig_go_4, _gostring_* _swig_go_5, _gostring_* _swig_go_6, _gostring_* _swig_go_7) {
+intgo _wrap_CfdCreateAddress_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, intgo _swig_go_1, _gostring_ _swig_go_2, _gostring_ _swig_go_3, intgo _swig_go_4, _gostring_* _swig_go_5, _gostring_* _swig_go_6, _gostring_* _swig_go_7) {
   void *arg1 = (void *) 0 ;
   int arg2 ;
   char *arg3 = (char *) 0 ;
@@ -1001,7 +1001,7 @@ intgo _wrap_CfdCreateAddress_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, intgo _swi
 }
 
 
-intgo _wrap_CfdInitializeMultisigScript_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, intgo _swig_go_1, intgo _swig_go_2, void **_swig_go_3) {
+intgo _wrap_CfdInitializeMultisigScript_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, intgo _swig_go_1, intgo _swig_go_2, void **_swig_go_3) {
   void *arg1 = (void *) 0 ;
   int arg2 ;
   int arg3 ;
@@ -1020,7 +1020,7 @@ intgo _wrap_CfdInitializeMultisigScript_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0,
 }
 
 
-intgo _wrap_CfdAddMultisigScriptData_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, void *_swig_go_1, _gostring_ _swig_go_2) {
+intgo _wrap_CfdAddMultisigScriptData_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, void *_swig_go_1, _gostring_ _swig_go_2) {
   void *arg1 = (void *) 0 ;
   void *arg2 = (void *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -1042,7 +1042,7 @@ intgo _wrap_CfdAddMultisigScriptData_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, vo
 }
 
 
-intgo _wrap_CfdFinalizeMultisigScript_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, void *_swig_go_1, uint32_t *_swig_go_2, _gostring_* _swig_go_3, _gostring_* _swig_go_4, _gostring_* _swig_go_5) {
+intgo _wrap_CfdFinalizeMultisigScript_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, void *_swig_go_1, uint32_t *_swig_go_2, _gostring_* _swig_go_3, _gostring_* _swig_go_4, _gostring_* _swig_go_5) {
   void *arg1 = (void *) 0 ;
   void *arg2 = (void *) 0 ;
   uint32_t arg3 ;
@@ -1087,7 +1087,7 @@ intgo _wrap_CfdFinalizeMultisigScript_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, v
 }
 
 
-intgo _wrap_CfdFreeMultisigScriptHandle_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, void *_swig_go_1) {
+intgo _wrap_CfdFreeMultisigScriptHandle_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, void *_swig_go_1) {
   void *arg1 = (void *) 0 ;
   void *arg2 = (void *) 0 ;
   int result;
@@ -1102,7 +1102,7 @@ intgo _wrap_CfdFreeMultisigScriptHandle_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0,
 }
 
 
-intgo _wrap_CfdParseDescriptor_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, intgo _swig_go_2, _gostring_ _swig_go_3, void **_swig_go_4, uint32_t *_swig_go_5) {
+intgo _wrap_CfdParseDescriptor_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, intgo _swig_go_2, _gostring_ _swig_go_3, void **_swig_go_4, uint32_t *_swig_go_5) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   int arg3 ;
@@ -1135,7 +1135,7 @@ intgo _wrap_CfdParseDescriptor_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostrin
 }
 
 
-intgo _wrap_CfdGetDescriptorData_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, void *_swig_go_1, uint32_t *_swig_go_2, uint32_t *_swig_go_3, uint32_t *_swig_go_4, intgo *_swig_go_5, _gostring_* _swig_go_6, _gostring_* _swig_go_7, intgo *_swig_go_8, _gostring_* _swig_go_9, intgo *_swig_go_10, _gostring_* _swig_go_11, _gostring_* _swig_go_12, _gostring_* _swig_go_13, bool *_swig_go_14, uint32_t *_swig_go_15) {
+intgo _wrap_CfdGetDescriptorData_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, void *_swig_go_1, uint32_t *_swig_go_2, uint32_t *_swig_go_3, uint32_t *_swig_go_4, intgo *_swig_go_5, _gostring_* _swig_go_6, _gostring_* _swig_go_7, intgo *_swig_go_8, _gostring_* _swig_go_9, intgo *_swig_go_10, _gostring_* _swig_go_11, _gostring_* _swig_go_12, _gostring_* _swig_go_13, bool *_swig_go_14, uint32_t *_swig_go_15) {
   void *arg1 = (void *) 0 ;
   void *arg2 = (void *) 0 ;
   uint32_t arg3 ;
@@ -1215,7 +1215,7 @@ intgo _wrap_CfdGetDescriptorData_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, void *
 }
 
 
-intgo _wrap_CfdGetDescriptorMultisigKey_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, void *_swig_go_1, uint32_t *_swig_go_2, intgo *_swig_go_3, _gostring_* _swig_go_4, _gostring_* _swig_go_5, _gostring_* _swig_go_6) {
+intgo _wrap_CfdGetDescriptorMultisigKey_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, void *_swig_go_1, uint32_t *_swig_go_2, intgo *_swig_go_3, _gostring_* _swig_go_4, _gostring_* _swig_go_5, _gostring_* _swig_go_6) {
   void *arg1 = (void *) 0 ;
   void *arg2 = (void *) 0 ;
   uint32_t arg3 ;
@@ -1262,7 +1262,7 @@ intgo _wrap_CfdGetDescriptorMultisigKey_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0,
 }
 
 
-intgo _wrap_CfdFreeDescriptorHandle_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, void *_swig_go_1) {
+intgo _wrap_CfdFreeDescriptorHandle_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, void *_swig_go_1) {
   void *arg1 = (void *) 0 ;
   void *arg2 = (void *) 0 ;
   int result;
@@ -1277,7 +1277,7 @@ intgo _wrap_CfdFreeDescriptorHandle_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, voi
 }
 
 
-intgo _wrap_CfdGetAddressesFromMultisig_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, intgo _swig_go_2, intgo _swig_go_3, void **_swig_go_4, uint32_t *_swig_go_5) {
+intgo _wrap_CfdGetAddressesFromMultisig_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, intgo _swig_go_2, intgo _swig_go_3, void **_swig_go_4, uint32_t *_swig_go_5) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   int arg3 ;
@@ -1305,7 +1305,7 @@ intgo _wrap_CfdGetAddressesFromMultisig_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0,
 }
 
 
-intgo _wrap_CfdGetAddressFromMultisigKey_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, void *_swig_go_1, uint32_t *_swig_go_2, _gostring_* _swig_go_3, _gostring_* _swig_go_4) {
+intgo _wrap_CfdGetAddressFromMultisigKey_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, void *_swig_go_1, uint32_t *_swig_go_2, _gostring_* _swig_go_3, _gostring_* _swig_go_4) {
   void *arg1 = (void *) 0 ;
   void *arg2 = (void *) 0 ;
   uint32_t arg3 ;
@@ -1343,7 +1343,7 @@ intgo _wrap_CfdGetAddressFromMultisigKey_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0
 }
 
 
-intgo _wrap_CfdFreeAddressesMultisigHandle_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, void *_swig_go_1) {
+intgo _wrap_CfdFreeAddressesMultisigHandle_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, void *_swig_go_1) {
   void *arg1 = (void *) 0 ;
   void *arg2 = (void *) 0 ;
   int result;
@@ -1358,7 +1358,36 @@ intgo _wrap_CfdFreeAddressesMultisigHandle_cfdgo_6d81cf84a6c5cb9b(void *_swig_go
 }
 
 
-intgo _wrap_CfdCreateConfidentialAddress_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, _gostring_* _swig_go_3) {
+intgo _wrap_CfdGetAddressFromLockingScript_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, intgo _swig_go_2, _gostring_* _swig_go_3) {
+  void *arg1 = (void *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 ;
+  char **arg4 = (char **) 0 ;
+  int result;
+  intgo _swig_go_result;
+  
+  arg1 = *(void **)&_swig_go_0; 
+  
+  arg2 = (char *)malloc(_swig_go_1.n + 1);
+  memcpy(arg2, _swig_go_1.p, _swig_go_1.n);
+  arg2[_swig_go_1.n] = '\0';
+  
+  arg3 = (int)_swig_go_2; 
+  arg4 = *(char ***)&_swig_go_3; 
+  
+  result = (int)CfdGetAddressFromLockingScript(arg1,(char const *)arg2,arg3,arg4);
+  _swig_go_result = result; 
+  {
+    if (arg4 && *arg4) {
+      _swig_go_3->n = strlen(*arg4);
+    }
+  }
+  free(arg2); 
+  return _swig_go_result;
+}
+
+
+intgo _wrap_CfdCreateConfidentialAddress_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, _gostring_* _swig_go_3) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -1392,7 +1421,7 @@ intgo _wrap_CfdCreateConfidentialAddress_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0
 }
 
 
-intgo _wrap_CfdParseConfidentialAddress_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, _gostring_* _swig_go_2, _gostring_* _swig_go_3, intgo *_swig_go_4) {
+intgo _wrap_CfdParseConfidentialAddress_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, _gostring_* _swig_go_2, _gostring_* _swig_go_3, intgo *_swig_go_4) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   char **arg3 = (char **) 0 ;
@@ -1428,7 +1457,7 @@ intgo _wrap_CfdParseConfidentialAddress_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0,
 }
 
 
-intgo _wrap_CfdInitializeConfidentialTx_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, uint32_t *_swig_go_1, uint32_t *_swig_go_2, _gostring_* _swig_go_3) {
+intgo _wrap_CfdInitializeConfidentialTx_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, uint32_t *_swig_go_1, uint32_t *_swig_go_2, _gostring_* _swig_go_3) {
   void *arg1 = (void *) 0 ;
   uint32_t arg2 ;
   uint32_t arg3 ;
@@ -1466,7 +1495,7 @@ intgo _wrap_CfdInitializeConfidentialTx_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0,
 }
 
 
-intgo _wrap_CfdAddConfidentialTxIn_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, uint32_t *_swig_go_3, uint32_t *_swig_go_4, _gostring_* _swig_go_5) {
+intgo _wrap_CfdAddConfidentialTxIn_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, uint32_t *_swig_go_3, uint32_t *_swig_go_4, _gostring_* _swig_go_5) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -1518,7 +1547,7 @@ intgo _wrap_CfdAddConfidentialTxIn_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gos
 }
 
 
-intgo _wrap_CfdAddConfidentialTxOut_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, int64_t *_swig_go_3, _gostring_ _swig_go_4, _gostring_ _swig_go_5, _gostring_ _swig_go_6, _gostring_ _swig_go_7, _gostring_* _swig_go_8) {
+intgo _wrap_CfdAddConfidentialTxOut_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, int64_t *_swig_go_3, _gostring_ _swig_go_4, _gostring_ _swig_go_5, _gostring_ _swig_go_6, _gostring_ _swig_go_7, _gostring_* _swig_go_8) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -1589,7 +1618,7 @@ intgo _wrap_CfdAddConfidentialTxOut_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _go
 }
 
 
-intgo _wrap_CfdUpdateConfidentialTxOut_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, uint32_t *_swig_go_2, _gostring_ _swig_go_3, int64_t *_swig_go_4, _gostring_ _swig_go_5, _gostring_ _swig_go_6, _gostring_ _swig_go_7, _gostring_ _swig_go_8, _gostring_* _swig_go_9) {
+intgo _wrap_CfdUpdateConfidentialTxOut_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, uint32_t *_swig_go_2, _gostring_ _swig_go_3, int64_t *_swig_go_4, _gostring_ _swig_go_5, _gostring_ _swig_go_6, _gostring_ _swig_go_7, _gostring_ _swig_go_8, _gostring_* _swig_go_9) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   uint32_t arg3 ;
@@ -1669,7 +1698,58 @@ intgo _wrap_CfdUpdateConfidentialTxOut_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, 
 }
 
 
-intgo _wrap_CfdGetConfidentialTxIn_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, uint32_t *_swig_go_2, _gostring_* _swig_go_3, uint32_t *_swig_go_4, uint32_t *_swig_go_5, _gostring_* _swig_go_6) {
+intgo _wrap_CfdGetConfidentialTxInfo_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, _gostring_* _swig_go_2, _gostring_* _swig_go_3, _gostring_* _swig_go_4, uint32_t *_swig_go_5, uint32_t *_swig_go_6, uint32_t *_swig_go_7, uint32_t *_swig_go_8, uint32_t *_swig_go_9) {
+  void *arg1 = (void *) 0 ;
+  char *arg2 = (char *) 0 ;
+  char **arg3 = (char **) 0 ;
+  char **arg4 = (char **) 0 ;
+  char **arg5 = (char **) 0 ;
+  uint32_t *arg6 = (uint32_t *) 0 ;
+  uint32_t *arg7 = (uint32_t *) 0 ;
+  uint32_t *arg8 = (uint32_t *) 0 ;
+  uint32_t *arg9 = (uint32_t *) 0 ;
+  uint32_t *arg10 = (uint32_t *) 0 ;
+  int result;
+  intgo _swig_go_result;
+  
+  arg1 = *(void **)&_swig_go_0; 
+  
+  arg2 = (char *)malloc(_swig_go_1.n + 1);
+  memcpy(arg2, _swig_go_1.p, _swig_go_1.n);
+  arg2[_swig_go_1.n] = '\0';
+  
+  arg3 = *(char ***)&_swig_go_2; 
+  arg4 = *(char ***)&_swig_go_3; 
+  arg5 = *(char ***)&_swig_go_4; 
+  arg6 = *(uint32_t **)&_swig_go_5; 
+  arg7 = *(uint32_t **)&_swig_go_6; 
+  arg8 = *(uint32_t **)&_swig_go_7; 
+  arg9 = *(uint32_t **)&_swig_go_8; 
+  arg10 = *(uint32_t **)&_swig_go_9; 
+  
+  result = (int)CfdGetConfidentialTxInfo(arg1,(char const *)arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10);
+  _swig_go_result = result; 
+  {
+    if (arg3 && *arg3) {
+      _swig_go_2->n = strlen(*arg3);
+    }
+  }
+  {
+    if (arg4 && *arg4) {
+      _swig_go_3->n = strlen(*arg4);
+    }
+  }
+  {
+    if (arg5 && *arg5) {
+      _swig_go_4->n = strlen(*arg5);
+    }
+  }
+  free(arg2); 
+  return _swig_go_result;
+}
+
+
+intgo _wrap_CfdGetConfidentialTxIn_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, uint32_t *_swig_go_2, _gostring_* _swig_go_3, uint32_t *_swig_go_4, uint32_t *_swig_go_5, _gostring_* _swig_go_6) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   uint32_t arg3 ;
@@ -1716,7 +1796,7 @@ intgo _wrap_CfdGetConfidentialTxIn_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gos
 }
 
 
-intgo _wrap_CfdGetConfidentialTxInWitness_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, uint32_t *_swig_go_2, uint32_t *_swig_go_3, _gostring_* _swig_go_4) {
+intgo _wrap_CfdGetConfidentialTxInWitness_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, uint32_t *_swig_go_2, uint32_t *_swig_go_3, _gostring_* _swig_go_4) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   uint32_t arg3 ;
@@ -1761,7 +1841,7 @@ intgo _wrap_CfdGetConfidentialTxInWitness_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_
 }
 
 
-intgo _wrap_CfdGetTxInIssuanceInfo_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, uint32_t *_swig_go_2, _gostring_* _swig_go_3, _gostring_* _swig_go_4, int64_t *_swig_go_5, _gostring_* _swig_go_6, int64_t *_swig_go_7, _gostring_* _swig_go_8, _gostring_* _swig_go_9, _gostring_* _swig_go_10) {
+intgo _wrap_CfdGetTxInIssuanceInfo_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, uint32_t *_swig_go_2, _gostring_* _swig_go_3, _gostring_* _swig_go_4, int64_t *_swig_go_5, _gostring_* _swig_go_6, int64_t *_swig_go_7, _gostring_* _swig_go_8, _gostring_* _swig_go_9, _gostring_* _swig_go_10) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   uint32_t arg3 ;
@@ -1836,7 +1916,7 @@ intgo _wrap_CfdGetTxInIssuanceInfo_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gos
 }
 
 
-intgo _wrap_CfdGetConfidentialTxOut_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, uint32_t *_swig_go_2, _gostring_* _swig_go_3, int64_t *_swig_go_4, _gostring_* _swig_go_5, _gostring_* _swig_go_6, _gostring_* _swig_go_7, _gostring_* _swig_go_8, _gostring_* _swig_go_9) {
+intgo _wrap_CfdGetConfidentialTxOut_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, uint32_t *_swig_go_2, _gostring_* _swig_go_3, int64_t *_swig_go_4, _gostring_* _swig_go_5, _gostring_* _swig_go_6, _gostring_* _swig_go_7, _gostring_* _swig_go_8, _gostring_* _swig_go_9) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   uint32_t arg3 ;
@@ -1909,7 +1989,7 @@ intgo _wrap_CfdGetConfidentialTxOut_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _go
 }
 
 
-intgo _wrap_CfdGetConfidentialTxInCount_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, uint32_t *_swig_go_2) {
+intgo _wrap_CfdGetConfidentialTxInCount_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, uint32_t *_swig_go_2) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   uint32_t *arg3 = (uint32_t *) 0 ;
@@ -1931,7 +2011,7 @@ intgo _wrap_CfdGetConfidentialTxInCount_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0,
 }
 
 
-intgo _wrap_CfdGetConfidentialTxInWitnessCount_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, uint32_t *_swig_go_2, uint32_t *_swig_go_3) {
+intgo _wrap_CfdGetConfidentialTxInWitnessCount_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, uint32_t *_swig_go_2, uint32_t *_swig_go_3) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   uint32_t arg3 ;
@@ -1962,7 +2042,7 @@ intgo _wrap_CfdGetConfidentialTxInWitnessCount_cfdgo_6d81cf84a6c5cb9b(void *_swi
 }
 
 
-intgo _wrap_CfdGetConfidentialTxOutCount_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, uint32_t *_swig_go_2) {
+intgo _wrap_CfdGetConfidentialTxOutCount_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, uint32_t *_swig_go_2) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   uint32_t *arg3 = (uint32_t *) 0 ;
@@ -1984,7 +2064,7 @@ intgo _wrap_CfdGetConfidentialTxOutCount_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0
 }
 
 
-intgo _wrap_CfdSetRawReissueAsset_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, uint32_t *_swig_go_3, int64_t *_swig_go_4, _gostring_ _swig_go_5, _gostring_ _swig_go_6, _gostring_ _swig_go_7, _gostring_ _swig_go_8, _gostring_* _swig_go_9, _gostring_* _swig_go_10) {
+intgo _wrap_CfdSetRawReissueAsset_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, uint32_t *_swig_go_3, int64_t *_swig_go_4, _gostring_ _swig_go_5, _gostring_ _swig_go_6, _gostring_ _swig_go_7, _gostring_ _swig_go_8, _gostring_* _swig_go_9, _gostring_* _swig_go_10) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -2071,7 +2151,7 @@ intgo _wrap_CfdSetRawReissueAsset_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gost
 }
 
 
-intgo _wrap_CfdGetIssuanceBlindingKey_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, uint32_t *_swig_go_3, _gostring_* _swig_go_4) {
+intgo _wrap_CfdGetIssuanceBlindingKey_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, uint32_t *_swig_go_3, _gostring_* _swig_go_4) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -2114,7 +2194,7 @@ intgo _wrap_CfdGetIssuanceBlindingKey_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _
 }
 
 
-intgo _wrap_CfdInitializeBlindTx_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, void **_swig_go_1) {
+intgo _wrap_CfdInitializeBlindTx_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, void **_swig_go_1) {
   void *arg1 = (void *) 0 ;
   void **arg2 = (void **) 0 ;
   int result;
@@ -2129,7 +2209,7 @@ intgo _wrap_CfdInitializeBlindTx_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, void *
 }
 
 
-intgo _wrap_CfdAddBlindTxInData_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, void *_swig_go_1, _gostring_ _swig_go_2, uint32_t *_swig_go_3, _gostring_ _swig_go_4, _gostring_ _swig_go_5, _gostring_ _swig_go_6, int64_t *_swig_go_7, _gostring_ _swig_go_8, _gostring_ _swig_go_9) {
+intgo _wrap_CfdAddBlindTxInData_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, void *_swig_go_1, _gostring_ _swig_go_2, uint32_t *_swig_go_3, _gostring_ _swig_go_4, _gostring_ _swig_go_5, _gostring_ _swig_go_6, int64_t *_swig_go_7, _gostring_ _swig_go_8, _gostring_ _swig_go_9) {
   void *arg1 = (void *) 0 ;
   void *arg2 = (void *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -2204,7 +2284,7 @@ intgo _wrap_CfdAddBlindTxInData_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, void *_
 }
 
 
-intgo _wrap_CfdAddBlindTxOutData_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, void *_swig_go_1, uint32_t *_swig_go_2, _gostring_ _swig_go_3) {
+intgo _wrap_CfdAddBlindTxOutData_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, void *_swig_go_1, uint32_t *_swig_go_2, _gostring_ _swig_go_3) {
   void *arg1 = (void *) 0 ;
   void *arg2 = (void *) 0 ;
   uint32_t arg3 ;
@@ -2235,7 +2315,7 @@ intgo _wrap_CfdAddBlindTxOutData_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, void *
 }
 
 
-intgo _wrap_CfdFinalizeBlindTx_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, void *_swig_go_1, _gostring_ _swig_go_2, _gostring_* _swig_go_3) {
+intgo _wrap_CfdFinalizeBlindTx_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, void *_swig_go_1, _gostring_ _swig_go_2, _gostring_* _swig_go_3) {
   void *arg1 = (void *) 0 ;
   void *arg2 = (void *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -2264,7 +2344,7 @@ intgo _wrap_CfdFinalizeBlindTx_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, void *_s
 }
 
 
-intgo _wrap_CfdFreeBlindHandle_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, void *_swig_go_1) {
+intgo _wrap_CfdFreeBlindHandle_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, void *_swig_go_1) {
   void *arg1 = (void *) 0 ;
   void *arg2 = (void *) 0 ;
   int result;
@@ -2279,7 +2359,7 @@ intgo _wrap_CfdFreeBlindHandle_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, void *_s
 }
 
 
-intgo _wrap_CfdAddConfidentialTxSign_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, uint32_t *_swig_go_3, bool _swig_go_4, _gostring_ _swig_go_5, bool _swig_go_6, _gostring_* _swig_go_7) {
+intgo _wrap_CfdAddConfidentialTxSign_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, uint32_t *_swig_go_3, bool _swig_go_4, _gostring_ _swig_go_5, bool _swig_go_6, _gostring_* _swig_go_7) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -2333,7 +2413,7 @@ intgo _wrap_CfdAddConfidentialTxSign_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _g
 }
 
 
-intgo _wrap_CfdAddConfidentialTxDerSign_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, uint32_t *_swig_go_3, bool _swig_go_4, _gostring_ _swig_go_5, intgo _swig_go_6, bool _swig_go_7, bool _swig_go_8, _gostring_* _swig_go_9) {
+intgo _wrap_CfdAddConfidentialTxDerSign_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, uint32_t *_swig_go_3, bool _swig_go_4, _gostring_ _swig_go_5, intgo _swig_go_6, bool _swig_go_7, bool _swig_go_8, _gostring_* _swig_go_9) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -2391,7 +2471,7 @@ intgo _wrap_CfdAddConfidentialTxDerSign_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0,
 }
 
 
-intgo _wrap_CfdFinalizeElementsMultisigSign_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, void *_swig_go_1, _gostring_ _swig_go_2, _gostring_ _swig_go_3, uint32_t *_swig_go_4, intgo _swig_go_5, _gostring_ _swig_go_6, _gostring_ _swig_go_7, bool _swig_go_8, _gostring_* _swig_go_9) {
+intgo _wrap_CfdFinalizeElementsMultisigSign_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, void *_swig_go_1, _gostring_ _swig_go_2, _gostring_ _swig_go_3, uint32_t *_swig_go_4, intgo _swig_go_5, _gostring_ _swig_go_6, _gostring_ _swig_go_7, bool _swig_go_8, _gostring_* _swig_go_9) {
   void *arg1 = (void *) 0 ;
   void *arg2 = (void *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -2454,7 +2534,7 @@ intgo _wrap_CfdFinalizeElementsMultisigSign_cfdgo_6d81cf84a6c5cb9b(void *_swig_g
 }
 
 
-intgo _wrap_CfdCreateConfidentialSighash_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, uint32_t *_swig_go_3, intgo _swig_go_4, _gostring_ _swig_go_5, _gostring_ _swig_go_6, int64_t *_swig_go_7, _gostring_ _swig_go_8, intgo _swig_go_9, bool _swig_go_10, _gostring_* _swig_go_11) {
+intgo _wrap_CfdCreateConfidentialSighash_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, uint32_t *_swig_go_3, intgo _swig_go_4, _gostring_ _swig_go_5, _gostring_ _swig_go_6, int64_t *_swig_go_7, _gostring_ _swig_go_8, intgo _swig_go_9, bool _swig_go_10, _gostring_* _swig_go_11) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -2533,7 +2613,7 @@ intgo _wrap_CfdCreateConfidentialSighash_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0
 }
 
 
-intgo _wrap_CfdUnblindTxOut_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, uint32_t *_swig_go_2, _gostring_ _swig_go_3, _gostring_* _swig_go_4, int64_t *_swig_go_5, _gostring_* _swig_go_6, _gostring_* _swig_go_7) {
+intgo _wrap_CfdUnblindTxOut_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, uint32_t *_swig_go_2, _gostring_ _swig_go_3, _gostring_* _swig_go_4, int64_t *_swig_go_5, _gostring_* _swig_go_6, _gostring_* _swig_go_7) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   uint32_t arg3 ;
@@ -2592,7 +2672,7 @@ intgo _wrap_CfdUnblindTxOut_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ 
 }
 
 
-intgo _wrap_CfdUnblindIssuance_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, uint32_t *_swig_go_2, _gostring_ _swig_go_3, _gostring_ _swig_go_4, _gostring_* _swig_go_5, int64_t *_swig_go_6, _gostring_* _swig_go_7, _gostring_* _swig_go_8, _gostring_* _swig_go_9, int64_t *_swig_go_10, _gostring_* _swig_go_11, _gostring_* _swig_go_12) {
+intgo _wrap_CfdUnblindIssuance_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, uint32_t *_swig_go_2, _gostring_ _swig_go_3, _gostring_ _swig_go_4, _gostring_* _swig_go_5, int64_t *_swig_go_6, _gostring_* _swig_go_7, _gostring_* _swig_go_8, _gostring_* _swig_go_9, int64_t *_swig_go_10, _gostring_* _swig_go_11, _gostring_* _swig_go_12) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   uint32_t arg3 ;
@@ -2681,7 +2761,7 @@ intgo _wrap_CfdUnblindIssuance_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostrin
 }
 
 
-intgo _wrap_kCfdExtPrivkey_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdExtPrivkey_cfdgo_3cf2a94eb1b532b7() {
   enum CfdExtKeyType result;
   intgo _swig_go_result;
   
@@ -2693,7 +2773,7 @@ intgo _wrap_kCfdExtPrivkey_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdExtPubkey_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdExtPubkey_cfdgo_3cf2a94eb1b532b7() {
   enum CfdExtKeyType result;
   intgo _swig_go_result;
   
@@ -2705,7 +2785,7 @@ intgo _wrap_kCfdExtPubkey_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_CfdCalculateEcSignature_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, _gostring_ _swig_go_3, intgo _swig_go_4, bool _swig_go_5, _gostring_* _swig_go_6) {
+intgo _wrap_CfdCalculateEcSignature_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, _gostring_ _swig_go_3, intgo _swig_go_4, bool _swig_go_5, _gostring_* _swig_go_6) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -2750,7 +2830,7 @@ intgo _wrap_CfdCalculateEcSignature_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _go
 }
 
 
-intgo _wrap_CfdCreateKeyPair_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, bool _swig_go_1, intgo _swig_go_2, _gostring_* _swig_go_3, _gostring_* _swig_go_4, _gostring_* _swig_go_5) {
+intgo _wrap_CfdCreateKeyPair_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, bool _swig_go_1, intgo _swig_go_2, _gostring_* _swig_go_3, _gostring_* _swig_go_4, _gostring_* _swig_go_5) {
   void *arg1 = (void *) 0 ;
   bool arg2 ;
   int arg3 ;
@@ -2788,7 +2868,7 @@ intgo _wrap_CfdCreateKeyPair_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, bool _swig
 }
 
 
-intgo _wrap_CfdGetPrivkeyFromWif_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, intgo _swig_go_2, _gostring_* _swig_go_3) {
+intgo _wrap_CfdGetPrivkeyFromWif_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, intgo _swig_go_2, _gostring_* _swig_go_3) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   int arg3 ;
@@ -2817,7 +2897,7 @@ intgo _wrap_CfdGetPrivkeyFromWif_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostr
 }
 
 
-intgo _wrap_CfdGetPubkeyFromPrivkey_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, bool _swig_go_3, _gostring_* _swig_go_4) {
+intgo _wrap_CfdGetPubkeyFromPrivkey_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, bool _swig_go_3, _gostring_* _swig_go_4) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -2853,7 +2933,7 @@ intgo _wrap_CfdGetPubkeyFromPrivkey_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _go
 }
 
 
-intgo _wrap_CfdCreateExtkeyFromSeed_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, intgo _swig_go_2, intgo _swig_go_3, _gostring_* _swig_go_4) {
+intgo _wrap_CfdCreateExtkeyFromSeed_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, intgo _swig_go_2, intgo _swig_go_3, _gostring_* _swig_go_4) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   int arg3 ;
@@ -2884,7 +2964,7 @@ intgo _wrap_CfdCreateExtkeyFromSeed_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _go
 }
 
 
-intgo _wrap_CfdCreateExtkeyFromParentPath_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, intgo _swig_go_3, intgo _swig_go_4, _gostring_* _swig_go_5) {
+intgo _wrap_CfdCreateExtkeyFromParentPath_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, intgo _swig_go_3, intgo _swig_go_4, _gostring_* _swig_go_5) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -2922,7 +3002,7 @@ intgo _wrap_CfdCreateExtkeyFromParentPath_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_
 }
 
 
-intgo _wrap_CfdCreateExtPubkey_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, intgo _swig_go_2, _gostring_* _swig_go_3) {
+intgo _wrap_CfdCreateExtPubkey_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, intgo _swig_go_2, _gostring_* _swig_go_3) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   int arg3 ;
@@ -2951,7 +3031,7 @@ intgo _wrap_CfdCreateExtPubkey_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostrin
 }
 
 
-intgo _wrap_CfdGetPrivkeyFromExtkey_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, intgo _swig_go_2, _gostring_* _swig_go_3, _gostring_* _swig_go_4) {
+intgo _wrap_CfdGetPrivkeyFromExtkey_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, intgo _swig_go_2, _gostring_* _swig_go_3, _gostring_* _swig_go_4) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   int arg3 ;
@@ -2987,7 +3067,7 @@ intgo _wrap_CfdGetPrivkeyFromExtkey_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _go
 }
 
 
-intgo _wrap_CfdGetPubkeyFromExtkey_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, intgo _swig_go_2, _gostring_* _swig_go_3) {
+intgo _wrap_CfdGetPubkeyFromExtkey_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, intgo _swig_go_2, _gostring_* _swig_go_3) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   int arg3 ;
@@ -3016,7 +3096,7 @@ intgo _wrap_CfdGetPubkeyFromExtkey_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gos
 }
 
 
-intgo _wrap_CfdParseScript_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _swig_go_1, void **_swig_go_2, uint32_t *_swig_go_3) {
+intgo _wrap_CfdParseScript_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, _gostring_ _swig_go_1, void **_swig_go_2, uint32_t *_swig_go_3) {
   void *arg1 = (void *) 0 ;
   char *arg2 = (char *) 0 ;
   void **arg3 = (void **) 0 ;
@@ -3040,7 +3120,7 @@ intgo _wrap_CfdParseScript_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, _gostring_ _
 }
 
 
-intgo _wrap_CfdGetScriptItem_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, void *_swig_go_1, uint32_t *_swig_go_2, _gostring_* _swig_go_3) {
+intgo _wrap_CfdGetScriptItem_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, void *_swig_go_1, uint32_t *_swig_go_2, _gostring_* _swig_go_3) {
   void *arg1 = (void *) 0 ;
   void *arg2 = (void *) 0 ;
   uint32_t arg3 ;
@@ -3071,7 +3151,7 @@ intgo _wrap_CfdGetScriptItem_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, void *_swi
 }
 
 
-intgo _wrap_CfdFreeScriptItemHandle_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, void *_swig_go_1) {
+intgo _wrap_CfdFreeScriptItemHandle_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, void *_swig_go_1) {
   void *arg1 = (void *) 0 ;
   void *arg2 = (void *) 0 ;
   int result;
@@ -3086,7 +3166,7 @@ intgo _wrap_CfdFreeScriptItemHandle_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, voi
 }
 
 
-intgo _wrap_kCfdSequenceLockTimeDisable_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdSequenceLockTimeDisable_cfdgo_3cf2a94eb1b532b7() {
   enum CfdSequenceLockTime result;
   intgo _swig_go_result;
   
@@ -3098,7 +3178,7 @@ intgo _wrap_kCfdSequenceLockTimeDisable_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_kCfdSequenceLockTimeEnableMax_cfdgo_6d81cf84a6c5cb9b() {
+intgo _wrap_kCfdSequenceLockTimeEnableMax_cfdgo_3cf2a94eb1b532b7() {
   enum CfdSequenceLockTime result;
   intgo _swig_go_result;
   
@@ -3110,7 +3190,7 @@ intgo _wrap_kCfdSequenceLockTimeEnableMax_cfdgo_6d81cf84a6c5cb9b() {
 }
 
 
-intgo _wrap_CfdInitializeMultisigSign_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, void **_swig_go_1) {
+intgo _wrap_CfdInitializeMultisigSign_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, void **_swig_go_1) {
   void *arg1 = (void *) 0 ;
   void **arg2 = (void **) 0 ;
   int result;
@@ -3125,7 +3205,7 @@ intgo _wrap_CfdInitializeMultisigSign_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, v
 }
 
 
-intgo _wrap_CfdAddMultisigSignData_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, void *_swig_go_1, _gostring_ _swig_go_2, _gostring_ _swig_go_3) {
+intgo _wrap_CfdAddMultisigSignData_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, void *_swig_go_1, _gostring_ _swig_go_2, _gostring_ _swig_go_3) {
   void *arg1 = (void *) 0 ;
   void *arg2 = (void *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -3154,7 +3234,7 @@ intgo _wrap_CfdAddMultisigSignData_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, void
 }
 
 
-intgo _wrap_CfdAddMultisigSignDataToDer_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, void *_swig_go_1, _gostring_ _swig_go_2, intgo _swig_go_3, bool _swig_go_4, _gostring_ _swig_go_5) {
+intgo _wrap_CfdAddMultisigSignDataToDer_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, void *_swig_go_1, _gostring_ _swig_go_2, intgo _swig_go_3, bool _swig_go_4, _gostring_ _swig_go_5) {
   void *arg1 = (void *) 0 ;
   void *arg2 = (void *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -3187,7 +3267,7 @@ intgo _wrap_CfdAddMultisigSignDataToDer_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0,
 }
 
 
-intgo _wrap_CfdFreeMultisigSignHandle_cfdgo_6d81cf84a6c5cb9b(void *_swig_go_0, void *_swig_go_1) {
+intgo _wrap_CfdFreeMultisigSignHandle_cfdgo_3cf2a94eb1b532b7(void *_swig_go_0, void *_swig_go_1) {
   void *arg1 = (void *) 0 ;
   void *arg2 = (void *) 0 ;
   int result;

--- a/cfdgo.go
+++ b/cfdgo.go
@@ -115,123 +115,127 @@ typedef _gostring_ swig_type_80;
 typedef _gostring_ swig_type_81;
 typedef _gostring_ swig_type_82;
 typedef _gostring_ swig_type_83;
-extern void _wrap_Swig_free_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1);
-extern uintptr_t _wrap_Swig_malloc_cfdgo_6d81cf84a6c5cb9b(swig_intgo arg1);
-extern swig_intgo _wrap_kCfdSuccess_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdUnknownError_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdInternalError_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdMemoryFullError_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdIllegalArgumentError_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdIllegalStateError_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdOutOfRangeError_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdInvalidSettingError_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdConnectionError_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdDiskAccessError_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdEnableBitcoin_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdEnableElements_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_CfdGetSupportedFunction_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1);
-extern swig_intgo _wrap_CfdInitialize_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_CfdFinalize_cfdgo_6d81cf84a6c5cb9b(_Bool arg1);
-extern swig_intgo _wrap_CfdCreateHandle_cfdgo_6d81cf84a6c5cb9b(swig_voidp arg1);
-extern swig_intgo _wrap_CfdCreateSimpleHandle_cfdgo_6d81cf84a6c5cb9b(swig_voidp arg1);
-extern swig_intgo _wrap_CfdFreeHandle_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1);
-extern swig_intgo _wrap_CfdFreeBuffer_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1);
-extern swig_intgo _wrap_CfdGetLastErrorCode_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1);
-extern swig_intgo _wrap_CfdGetLastErrorMessage_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_voidp arg2);
-extern swig_intgo _wrap_kCfdNetworkMainnet_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdNetworkTestnet_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdNetworkRegtest_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdNetworkLiquidv1_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdNetworkElementsRegtest_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdNetworkCustomChain_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdP2shAddress_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdP2pkhAddress_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdP2wshAddress_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdP2wpkhAddress_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdP2shP2wshAddress_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdP2shP2wpkhAddress_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdP2sh_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdP2pkh_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdP2wsh_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdP2wpkh_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdP2shP2wsh_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdP2shP2wpkh_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdSigHashAll_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdSigHashNone_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdSigHashSingle_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdDescriptorScriptNull_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdDescriptorScriptSh_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdDescriptorScriptWsh_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdDescriptorScriptPk_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdDescriptorScriptPkh_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdDescriptorScriptWpkh_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdDescriptorScriptCombo_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdDescriptorScriptMulti_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdDescriptorScriptSortedMulti_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdDescriptorScriptAddr_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdDescriptorScriptRaw_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdDescriptorKeyNull_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdDescriptorKeyPublic_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdDescriptorKeyBip32_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdDescriptorKeyBip32Priv_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_CfdCreateAddress_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_intgo arg2, swig_type_1 arg3, swig_type_2 arg4, swig_intgo arg5, swig_voidp arg6, swig_voidp arg7, swig_voidp arg8);
-extern swig_intgo _wrap_CfdInitializeMultisigScript_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_intgo arg2, swig_intgo arg3, swig_voidp arg4);
-extern swig_intgo _wrap_CfdAddMultisigScriptData_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, uintptr_t arg2, swig_type_3 arg3);
-extern swig_intgo _wrap_CfdFinalizeMultisigScript_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, uintptr_t arg2, uintptr_t arg3, swig_voidp arg4, swig_voidp arg5, swig_voidp arg6);
-extern swig_intgo _wrap_CfdFreeMultisigScriptHandle_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, uintptr_t arg2);
-extern swig_intgo _wrap_CfdParseDescriptor_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_4 arg2, swig_intgo arg3, swig_type_5 arg4, swig_voidp arg5, uintptr_t arg6);
-extern swig_intgo _wrap_CfdGetDescriptorData_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, uintptr_t arg2, uintptr_t arg3, uintptr_t arg4, uintptr_t arg5, swig_voidp arg6, swig_voidp arg7, swig_voidp arg8, swig_voidp arg9, swig_voidp arg10, swig_voidp arg11, swig_voidp arg12, swig_voidp arg13, swig_voidp arg14, swig_voidp arg15, uintptr_t arg16);
-extern swig_intgo _wrap_CfdGetDescriptorMultisigKey_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, uintptr_t arg2, uintptr_t arg3, swig_voidp arg4, swig_voidp arg5, swig_voidp arg6, swig_voidp arg7);
-extern swig_intgo _wrap_CfdFreeDescriptorHandle_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, uintptr_t arg2);
-extern swig_intgo _wrap_CfdGetAddressesFromMultisig_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_6 arg2, swig_intgo arg3, swig_intgo arg4, swig_voidp arg5, uintptr_t arg6);
-extern swig_intgo _wrap_CfdGetAddressFromMultisigKey_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, uintptr_t arg2, uintptr_t arg3, swig_voidp arg4, swig_voidp arg5);
-extern swig_intgo _wrap_CfdFreeAddressesMultisigHandle_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, uintptr_t arg2);
-extern swig_intgo _wrap_CfdCreateConfidentialAddress_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_7 arg2, swig_type_8 arg3, swig_voidp arg4);
-extern swig_intgo _wrap_CfdParseConfidentialAddress_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_9 arg2, swig_voidp arg3, swig_voidp arg4, swig_voidp arg5);
-extern swig_intgo _wrap_CfdInitializeConfidentialTx_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, uintptr_t arg2, uintptr_t arg3, swig_voidp arg4);
-extern swig_intgo _wrap_CfdAddConfidentialTxIn_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_10 arg2, swig_type_11 arg3, uintptr_t arg4, uintptr_t arg5, swig_voidp arg6);
-extern swig_intgo _wrap_CfdAddConfidentialTxOut_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_12 arg2, swig_type_13 arg3, uintptr_t arg4, swig_type_14 arg5, swig_type_15 arg6, swig_type_16 arg7, swig_type_17 arg8, swig_voidp arg9);
-extern swig_intgo _wrap_CfdUpdateConfidentialTxOut_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_18 arg2, uintptr_t arg3, swig_type_19 arg4, uintptr_t arg5, swig_type_20 arg6, swig_type_21 arg7, swig_type_22 arg8, swig_type_23 arg9, swig_voidp arg10);
-extern swig_intgo _wrap_CfdGetConfidentialTxIn_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_24 arg2, uintptr_t arg3, swig_voidp arg4, uintptr_t arg5, uintptr_t arg6, swig_voidp arg7);
-extern swig_intgo _wrap_CfdGetConfidentialTxInWitness_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_25 arg2, uintptr_t arg3, uintptr_t arg4, swig_voidp arg5);
-extern swig_intgo _wrap_CfdGetTxInIssuanceInfo_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_26 arg2, uintptr_t arg3, swig_voidp arg4, swig_voidp arg5, uintptr_t arg6, swig_voidp arg7, uintptr_t arg8, swig_voidp arg9, swig_voidp arg10, swig_voidp arg11);
-extern swig_intgo _wrap_CfdGetConfidentialTxOut_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_27 arg2, uintptr_t arg3, swig_voidp arg4, uintptr_t arg5, swig_voidp arg6, swig_voidp arg7, swig_voidp arg8, swig_voidp arg9, swig_voidp arg10);
-extern swig_intgo _wrap_CfdGetConfidentialTxInCount_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_28 arg2, uintptr_t arg3);
-extern swig_intgo _wrap_CfdGetConfidentialTxInWitnessCount_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_29 arg2, uintptr_t arg3, uintptr_t arg4);
-extern swig_intgo _wrap_CfdGetConfidentialTxOutCount_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_30 arg2, uintptr_t arg3);
-extern swig_intgo _wrap_CfdSetRawReissueAsset_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_31 arg2, swig_type_32 arg3, uintptr_t arg4, uintptr_t arg5, swig_type_33 arg6, swig_type_34 arg7, swig_type_35 arg8, swig_type_36 arg9, swig_voidp arg10, swig_voidp arg11);
-extern swig_intgo _wrap_CfdGetIssuanceBlindingKey_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_37 arg2, swig_type_38 arg3, uintptr_t arg4, swig_voidp arg5);
-extern swig_intgo _wrap_CfdInitializeBlindTx_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_voidp arg2);
-extern swig_intgo _wrap_CfdAddBlindTxInData_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, uintptr_t arg2, swig_type_39 arg3, uintptr_t arg4, swig_type_40 arg5, swig_type_41 arg6, swig_type_42 arg7, uintptr_t arg8, swig_type_43 arg9, swig_type_44 arg10);
-extern swig_intgo _wrap_CfdAddBlindTxOutData_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, uintptr_t arg2, uintptr_t arg3, swig_type_45 arg4);
-extern swig_intgo _wrap_CfdFinalizeBlindTx_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, uintptr_t arg2, swig_type_46 arg3, swig_voidp arg4);
-extern swig_intgo _wrap_CfdFreeBlindHandle_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, uintptr_t arg2);
-extern swig_intgo _wrap_CfdAddConfidentialTxSign_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_47 arg2, swig_type_48 arg3, uintptr_t arg4, _Bool arg5, swig_type_49 arg6, _Bool arg7, swig_voidp arg8);
-extern swig_intgo _wrap_CfdAddConfidentialTxDerSign_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_50 arg2, swig_type_51 arg3, uintptr_t arg4, _Bool arg5, swig_type_52 arg6, swig_intgo arg7, _Bool arg8, _Bool arg9, swig_voidp arg10);
-extern swig_intgo _wrap_CfdFinalizeElementsMultisigSign_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, uintptr_t arg2, swig_type_53 arg3, swig_type_54 arg4, uintptr_t arg5, swig_intgo arg6, swig_type_55 arg7, swig_type_56 arg8, _Bool arg9, swig_voidp arg10);
-extern swig_intgo _wrap_CfdCreateConfidentialSighash_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_57 arg2, swig_type_58 arg3, uintptr_t arg4, swig_intgo arg5, swig_type_59 arg6, swig_type_60 arg7, uintptr_t arg8, swig_type_61 arg9, swig_intgo arg10, _Bool arg11, swig_voidp arg12);
-extern swig_intgo _wrap_CfdUnblindTxOut_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_62 arg2, uintptr_t arg3, swig_type_63 arg4, swig_voidp arg5, uintptr_t arg6, swig_voidp arg7, swig_voidp arg8);
-extern swig_intgo _wrap_CfdUnblindIssuance_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_64 arg2, uintptr_t arg3, swig_type_65 arg4, swig_type_66 arg5, swig_voidp arg6, uintptr_t arg7, swig_voidp arg8, swig_voidp arg9, swig_voidp arg10, uintptr_t arg11, swig_voidp arg12, swig_voidp arg13);
-extern swig_intgo _wrap_kCfdExtPrivkey_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdExtPubkey_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_CfdCalculateEcSignature_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_67 arg2, swig_type_68 arg3, swig_type_69 arg4, swig_intgo arg5, _Bool arg6, swig_voidp arg7);
-extern swig_intgo _wrap_CfdCreateKeyPair_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, _Bool arg2, swig_intgo arg3, swig_voidp arg4, swig_voidp arg5, swig_voidp arg6);
-extern swig_intgo _wrap_CfdGetPrivkeyFromWif_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_70 arg2, swig_intgo arg3, swig_voidp arg4);
-extern swig_intgo _wrap_CfdGetPubkeyFromPrivkey_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_71 arg2, swig_type_72 arg3, _Bool arg4, swig_voidp arg5);
-extern swig_intgo _wrap_CfdCreateExtkeyFromSeed_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_73 arg2, swig_intgo arg3, swig_intgo arg4, swig_voidp arg5);
-extern swig_intgo _wrap_CfdCreateExtkeyFromParentPath_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_74 arg2, swig_type_75 arg3, swig_intgo arg4, swig_intgo arg5, swig_voidp arg6);
-extern swig_intgo _wrap_CfdCreateExtPubkey_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_76 arg2, swig_intgo arg3, swig_voidp arg4);
-extern swig_intgo _wrap_CfdGetPrivkeyFromExtkey_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_77 arg2, swig_intgo arg3, swig_voidp arg4, swig_voidp arg5);
-extern swig_intgo _wrap_CfdGetPubkeyFromExtkey_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_78 arg2, swig_intgo arg3, swig_voidp arg4);
-extern swig_intgo _wrap_CfdParseScript_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_type_79 arg2, swig_voidp arg3, uintptr_t arg4);
-extern swig_intgo _wrap_CfdGetScriptItem_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, uintptr_t arg2, uintptr_t arg3, swig_voidp arg4);
-extern swig_intgo _wrap_CfdFreeScriptItemHandle_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, uintptr_t arg2);
-extern swig_intgo _wrap_kCfdSequenceLockTimeDisable_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_kCfdSequenceLockTimeEnableMax_cfdgo_6d81cf84a6c5cb9b(void);
-extern swig_intgo _wrap_CfdInitializeMultisigSign_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, swig_voidp arg2);
-extern swig_intgo _wrap_CfdAddMultisigSignData_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, uintptr_t arg2, swig_type_80 arg3, swig_type_81 arg4);
-extern swig_intgo _wrap_CfdAddMultisigSignDataToDer_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, uintptr_t arg2, swig_type_82 arg3, swig_intgo arg4, _Bool arg5, swig_type_83 arg6);
-extern swig_intgo _wrap_CfdFreeMultisigSignHandle_cfdgo_6d81cf84a6c5cb9b(uintptr_t arg1, uintptr_t arg2);
+typedef _gostring_ swig_type_84;
+typedef _gostring_ swig_type_85;
+extern void _wrap_Swig_free_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1);
+extern uintptr_t _wrap_Swig_malloc_cfdgo_3cf2a94eb1b532b7(swig_intgo arg1);
+extern swig_intgo _wrap_kCfdSuccess_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdUnknownError_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdInternalError_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdMemoryFullError_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdIllegalArgumentError_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdIllegalStateError_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdOutOfRangeError_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdInvalidSettingError_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdConnectionError_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdDiskAccessError_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdEnableBitcoin_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdEnableElements_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_CfdGetSupportedFunction_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1);
+extern swig_intgo _wrap_CfdInitialize_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_CfdFinalize_cfdgo_3cf2a94eb1b532b7(_Bool arg1);
+extern swig_intgo _wrap_CfdCreateHandle_cfdgo_3cf2a94eb1b532b7(swig_voidp arg1);
+extern swig_intgo _wrap_CfdCreateSimpleHandle_cfdgo_3cf2a94eb1b532b7(swig_voidp arg1);
+extern swig_intgo _wrap_CfdFreeHandle_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1);
+extern swig_intgo _wrap_CfdFreeBuffer_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1);
+extern swig_intgo _wrap_CfdGetLastErrorCode_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1);
+extern swig_intgo _wrap_CfdGetLastErrorMessage_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_voidp arg2);
+extern swig_intgo _wrap_kCfdNetworkMainnet_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdNetworkTestnet_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdNetworkRegtest_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdNetworkLiquidv1_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdNetworkElementsRegtest_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdNetworkCustomChain_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdP2shAddress_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdP2pkhAddress_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdP2wshAddress_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdP2wpkhAddress_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdP2shP2wshAddress_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdP2shP2wpkhAddress_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdP2sh_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdP2pkh_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdP2wsh_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdP2wpkh_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdP2shP2wsh_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdP2shP2wpkh_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdSigHashAll_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdSigHashNone_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdSigHashSingle_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdDescriptorScriptNull_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdDescriptorScriptSh_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdDescriptorScriptWsh_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdDescriptorScriptPk_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdDescriptorScriptPkh_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdDescriptorScriptWpkh_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdDescriptorScriptCombo_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdDescriptorScriptMulti_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdDescriptorScriptSortedMulti_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdDescriptorScriptAddr_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdDescriptorScriptRaw_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdDescriptorKeyNull_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdDescriptorKeyPublic_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdDescriptorKeyBip32_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdDescriptorKeyBip32Priv_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_CfdCreateAddress_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_intgo arg2, swig_type_1 arg3, swig_type_2 arg4, swig_intgo arg5, swig_voidp arg6, swig_voidp arg7, swig_voidp arg8);
+extern swig_intgo _wrap_CfdInitializeMultisigScript_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_intgo arg2, swig_intgo arg3, swig_voidp arg4);
+extern swig_intgo _wrap_CfdAddMultisigScriptData_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, uintptr_t arg2, swig_type_3 arg3);
+extern swig_intgo _wrap_CfdFinalizeMultisigScript_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, uintptr_t arg2, uintptr_t arg3, swig_voidp arg4, swig_voidp arg5, swig_voidp arg6);
+extern swig_intgo _wrap_CfdFreeMultisigScriptHandle_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, uintptr_t arg2);
+extern swig_intgo _wrap_CfdParseDescriptor_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_4 arg2, swig_intgo arg3, swig_type_5 arg4, swig_voidp arg5, uintptr_t arg6);
+extern swig_intgo _wrap_CfdGetDescriptorData_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, uintptr_t arg2, uintptr_t arg3, uintptr_t arg4, uintptr_t arg5, swig_voidp arg6, swig_voidp arg7, swig_voidp arg8, swig_voidp arg9, swig_voidp arg10, swig_voidp arg11, swig_voidp arg12, swig_voidp arg13, swig_voidp arg14, swig_voidp arg15, uintptr_t arg16);
+extern swig_intgo _wrap_CfdGetDescriptorMultisigKey_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, uintptr_t arg2, uintptr_t arg3, swig_voidp arg4, swig_voidp arg5, swig_voidp arg6, swig_voidp arg7);
+extern swig_intgo _wrap_CfdFreeDescriptorHandle_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, uintptr_t arg2);
+extern swig_intgo _wrap_CfdGetAddressesFromMultisig_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_6 arg2, swig_intgo arg3, swig_intgo arg4, swig_voidp arg5, uintptr_t arg6);
+extern swig_intgo _wrap_CfdGetAddressFromMultisigKey_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, uintptr_t arg2, uintptr_t arg3, swig_voidp arg4, swig_voidp arg5);
+extern swig_intgo _wrap_CfdFreeAddressesMultisigHandle_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, uintptr_t arg2);
+extern swig_intgo _wrap_CfdGetAddressFromLockingScript_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_7 arg2, swig_intgo arg3, swig_voidp arg4);
+extern swig_intgo _wrap_CfdCreateConfidentialAddress_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_8 arg2, swig_type_9 arg3, swig_voidp arg4);
+extern swig_intgo _wrap_CfdParseConfidentialAddress_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_10 arg2, swig_voidp arg3, swig_voidp arg4, swig_voidp arg5);
+extern swig_intgo _wrap_CfdInitializeConfidentialTx_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, uintptr_t arg2, uintptr_t arg3, swig_voidp arg4);
+extern swig_intgo _wrap_CfdAddConfidentialTxIn_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_11 arg2, swig_type_12 arg3, uintptr_t arg4, uintptr_t arg5, swig_voidp arg6);
+extern swig_intgo _wrap_CfdAddConfidentialTxOut_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_13 arg2, swig_type_14 arg3, uintptr_t arg4, swig_type_15 arg5, swig_type_16 arg6, swig_type_17 arg7, swig_type_18 arg8, swig_voidp arg9);
+extern swig_intgo _wrap_CfdUpdateConfidentialTxOut_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_19 arg2, uintptr_t arg3, swig_type_20 arg4, uintptr_t arg5, swig_type_21 arg6, swig_type_22 arg7, swig_type_23 arg8, swig_type_24 arg9, swig_voidp arg10);
+extern swig_intgo _wrap_CfdGetConfidentialTxInfo_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_25 arg2, swig_voidp arg3, swig_voidp arg4, swig_voidp arg5, uintptr_t arg6, uintptr_t arg7, uintptr_t arg8, uintptr_t arg9, uintptr_t arg10);
+extern swig_intgo _wrap_CfdGetConfidentialTxIn_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_26 arg2, uintptr_t arg3, swig_voidp arg4, uintptr_t arg5, uintptr_t arg6, swig_voidp arg7);
+extern swig_intgo _wrap_CfdGetConfidentialTxInWitness_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_27 arg2, uintptr_t arg3, uintptr_t arg4, swig_voidp arg5);
+extern swig_intgo _wrap_CfdGetTxInIssuanceInfo_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_28 arg2, uintptr_t arg3, swig_voidp arg4, swig_voidp arg5, uintptr_t arg6, swig_voidp arg7, uintptr_t arg8, swig_voidp arg9, swig_voidp arg10, swig_voidp arg11);
+extern swig_intgo _wrap_CfdGetConfidentialTxOut_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_29 arg2, uintptr_t arg3, swig_voidp arg4, uintptr_t arg5, swig_voidp arg6, swig_voidp arg7, swig_voidp arg8, swig_voidp arg9, swig_voidp arg10);
+extern swig_intgo _wrap_CfdGetConfidentialTxInCount_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_30 arg2, uintptr_t arg3);
+extern swig_intgo _wrap_CfdGetConfidentialTxInWitnessCount_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_31 arg2, uintptr_t arg3, uintptr_t arg4);
+extern swig_intgo _wrap_CfdGetConfidentialTxOutCount_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_32 arg2, uintptr_t arg3);
+extern swig_intgo _wrap_CfdSetRawReissueAsset_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_33 arg2, swig_type_34 arg3, uintptr_t arg4, uintptr_t arg5, swig_type_35 arg6, swig_type_36 arg7, swig_type_37 arg8, swig_type_38 arg9, swig_voidp arg10, swig_voidp arg11);
+extern swig_intgo _wrap_CfdGetIssuanceBlindingKey_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_39 arg2, swig_type_40 arg3, uintptr_t arg4, swig_voidp arg5);
+extern swig_intgo _wrap_CfdInitializeBlindTx_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_voidp arg2);
+extern swig_intgo _wrap_CfdAddBlindTxInData_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, uintptr_t arg2, swig_type_41 arg3, uintptr_t arg4, swig_type_42 arg5, swig_type_43 arg6, swig_type_44 arg7, uintptr_t arg8, swig_type_45 arg9, swig_type_46 arg10);
+extern swig_intgo _wrap_CfdAddBlindTxOutData_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, uintptr_t arg2, uintptr_t arg3, swig_type_47 arg4);
+extern swig_intgo _wrap_CfdFinalizeBlindTx_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, uintptr_t arg2, swig_type_48 arg3, swig_voidp arg4);
+extern swig_intgo _wrap_CfdFreeBlindHandle_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, uintptr_t arg2);
+extern swig_intgo _wrap_CfdAddConfidentialTxSign_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_49 arg2, swig_type_50 arg3, uintptr_t arg4, _Bool arg5, swig_type_51 arg6, _Bool arg7, swig_voidp arg8);
+extern swig_intgo _wrap_CfdAddConfidentialTxDerSign_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_52 arg2, swig_type_53 arg3, uintptr_t arg4, _Bool arg5, swig_type_54 arg6, swig_intgo arg7, _Bool arg8, _Bool arg9, swig_voidp arg10);
+extern swig_intgo _wrap_CfdFinalizeElementsMultisigSign_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, uintptr_t arg2, swig_type_55 arg3, swig_type_56 arg4, uintptr_t arg5, swig_intgo arg6, swig_type_57 arg7, swig_type_58 arg8, _Bool arg9, swig_voidp arg10);
+extern swig_intgo _wrap_CfdCreateConfidentialSighash_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_59 arg2, swig_type_60 arg3, uintptr_t arg4, swig_intgo arg5, swig_type_61 arg6, swig_type_62 arg7, uintptr_t arg8, swig_type_63 arg9, swig_intgo arg10, _Bool arg11, swig_voidp arg12);
+extern swig_intgo _wrap_CfdUnblindTxOut_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_64 arg2, uintptr_t arg3, swig_type_65 arg4, swig_voidp arg5, uintptr_t arg6, swig_voidp arg7, swig_voidp arg8);
+extern swig_intgo _wrap_CfdUnblindIssuance_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_66 arg2, uintptr_t arg3, swig_type_67 arg4, swig_type_68 arg5, swig_voidp arg6, uintptr_t arg7, swig_voidp arg8, swig_voidp arg9, swig_voidp arg10, uintptr_t arg11, swig_voidp arg12, swig_voidp arg13);
+extern swig_intgo _wrap_kCfdExtPrivkey_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdExtPubkey_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_CfdCalculateEcSignature_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_69 arg2, swig_type_70 arg3, swig_type_71 arg4, swig_intgo arg5, _Bool arg6, swig_voidp arg7);
+extern swig_intgo _wrap_CfdCreateKeyPair_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, _Bool arg2, swig_intgo arg3, swig_voidp arg4, swig_voidp arg5, swig_voidp arg6);
+extern swig_intgo _wrap_CfdGetPrivkeyFromWif_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_72 arg2, swig_intgo arg3, swig_voidp arg4);
+extern swig_intgo _wrap_CfdGetPubkeyFromPrivkey_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_73 arg2, swig_type_74 arg3, _Bool arg4, swig_voidp arg5);
+extern swig_intgo _wrap_CfdCreateExtkeyFromSeed_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_75 arg2, swig_intgo arg3, swig_intgo arg4, swig_voidp arg5);
+extern swig_intgo _wrap_CfdCreateExtkeyFromParentPath_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_76 arg2, swig_type_77 arg3, swig_intgo arg4, swig_intgo arg5, swig_voidp arg6);
+extern swig_intgo _wrap_CfdCreateExtPubkey_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_78 arg2, swig_intgo arg3, swig_voidp arg4);
+extern swig_intgo _wrap_CfdGetPrivkeyFromExtkey_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_79 arg2, swig_intgo arg3, swig_voidp arg4, swig_voidp arg5);
+extern swig_intgo _wrap_CfdGetPubkeyFromExtkey_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_80 arg2, swig_intgo arg3, swig_voidp arg4);
+extern swig_intgo _wrap_CfdParseScript_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_type_81 arg2, swig_voidp arg3, uintptr_t arg4);
+extern swig_intgo _wrap_CfdGetScriptItem_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, uintptr_t arg2, uintptr_t arg3, swig_voidp arg4);
+extern swig_intgo _wrap_CfdFreeScriptItemHandle_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, uintptr_t arg2);
+extern swig_intgo _wrap_kCfdSequenceLockTimeDisable_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_kCfdSequenceLockTimeEnableMax_cfdgo_3cf2a94eb1b532b7(void);
+extern swig_intgo _wrap_CfdInitializeMultisigSign_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, swig_voidp arg2);
+extern swig_intgo _wrap_CfdAddMultisigSignData_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, uintptr_t arg2, swig_type_82 arg3, swig_type_83 arg4);
+extern swig_intgo _wrap_CfdAddMultisigSignDataToDer_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, uintptr_t arg2, swig_type_84 arg3, swig_intgo arg4, _Bool arg5, swig_type_85 arg6);
+extern swig_intgo _wrap_CfdFreeMultisigSignHandle_cfdgo_3cf2a94eb1b532b7(uintptr_t arg1, uintptr_t arg2);
 #undef intgo
 */
 import "C"
@@ -258,83 +262,83 @@ type _ sync.Mutex
 
 func Swig_free(arg1 uintptr) {
 	_swig_i_0 := arg1
-	C._wrap_Swig_free_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0))
+	C._wrap_Swig_free_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0))
 }
 
 func Swig_malloc(arg1 int) (_swig_ret uintptr) {
 	var swig_r uintptr
 	_swig_i_0 := arg1
-	swig_r = (uintptr)(C._wrap_Swig_malloc_cfdgo_6d81cf84a6c5cb9b(C.swig_intgo(_swig_i_0)))
+	swig_r = (uintptr)(C._wrap_Swig_malloc_cfdgo_3cf2a94eb1b532b7(C.swig_intgo(_swig_i_0)))
 	return swig_r
 }
 
 type Enum_SS_CfdErrorCode int
 func _swig_getkCfdSuccess() (_swig_ret Enum_SS_CfdErrorCode) {
 	var swig_r Enum_SS_CfdErrorCode
-	swig_r = (Enum_SS_CfdErrorCode)(C._wrap_kCfdSuccess_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdErrorCode)(C._wrap_kCfdSuccess_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdSuccess Enum_SS_CfdErrorCode = _swig_getkCfdSuccess()
 func _swig_getkCfdUnknownError() (_swig_ret Enum_SS_CfdErrorCode) {
 	var swig_r Enum_SS_CfdErrorCode
-	swig_r = (Enum_SS_CfdErrorCode)(C._wrap_kCfdUnknownError_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdErrorCode)(C._wrap_kCfdUnknownError_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdUnknownError Enum_SS_CfdErrorCode = _swig_getkCfdUnknownError()
 func _swig_getkCfdInternalError() (_swig_ret Enum_SS_CfdErrorCode) {
 	var swig_r Enum_SS_CfdErrorCode
-	swig_r = (Enum_SS_CfdErrorCode)(C._wrap_kCfdInternalError_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdErrorCode)(C._wrap_kCfdInternalError_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdInternalError Enum_SS_CfdErrorCode = _swig_getkCfdInternalError()
 func _swig_getkCfdMemoryFullError() (_swig_ret Enum_SS_CfdErrorCode) {
 	var swig_r Enum_SS_CfdErrorCode
-	swig_r = (Enum_SS_CfdErrorCode)(C._wrap_kCfdMemoryFullError_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdErrorCode)(C._wrap_kCfdMemoryFullError_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdMemoryFullError Enum_SS_CfdErrorCode = _swig_getkCfdMemoryFullError()
 func _swig_getkCfdIllegalArgumentError() (_swig_ret Enum_SS_CfdErrorCode) {
 	var swig_r Enum_SS_CfdErrorCode
-	swig_r = (Enum_SS_CfdErrorCode)(C._wrap_kCfdIllegalArgumentError_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdErrorCode)(C._wrap_kCfdIllegalArgumentError_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdIllegalArgumentError Enum_SS_CfdErrorCode = _swig_getkCfdIllegalArgumentError()
 func _swig_getkCfdIllegalStateError() (_swig_ret Enum_SS_CfdErrorCode) {
 	var swig_r Enum_SS_CfdErrorCode
-	swig_r = (Enum_SS_CfdErrorCode)(C._wrap_kCfdIllegalStateError_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdErrorCode)(C._wrap_kCfdIllegalStateError_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdIllegalStateError Enum_SS_CfdErrorCode = _swig_getkCfdIllegalStateError()
 func _swig_getkCfdOutOfRangeError() (_swig_ret Enum_SS_CfdErrorCode) {
 	var swig_r Enum_SS_CfdErrorCode
-	swig_r = (Enum_SS_CfdErrorCode)(C._wrap_kCfdOutOfRangeError_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdErrorCode)(C._wrap_kCfdOutOfRangeError_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdOutOfRangeError Enum_SS_CfdErrorCode = _swig_getkCfdOutOfRangeError()
 func _swig_getkCfdInvalidSettingError() (_swig_ret Enum_SS_CfdErrorCode) {
 	var swig_r Enum_SS_CfdErrorCode
-	swig_r = (Enum_SS_CfdErrorCode)(C._wrap_kCfdInvalidSettingError_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdErrorCode)(C._wrap_kCfdInvalidSettingError_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdInvalidSettingError Enum_SS_CfdErrorCode = _swig_getkCfdInvalidSettingError()
 func _swig_getkCfdConnectionError() (_swig_ret Enum_SS_CfdErrorCode) {
 	var swig_r Enum_SS_CfdErrorCode
-	swig_r = (Enum_SS_CfdErrorCode)(C._wrap_kCfdConnectionError_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdErrorCode)(C._wrap_kCfdConnectionError_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdConnectionError Enum_SS_CfdErrorCode = _swig_getkCfdConnectionError()
 func _swig_getkCfdDiskAccessError() (_swig_ret Enum_SS_CfdErrorCode) {
 	var swig_r Enum_SS_CfdErrorCode
-	swig_r = (Enum_SS_CfdErrorCode)(C._wrap_kCfdDiskAccessError_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdErrorCode)(C._wrap_kCfdDiskAccessError_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
@@ -342,14 +346,14 @@ var KCfdDiskAccessError Enum_SS_CfdErrorCode = _swig_getkCfdDiskAccessError()
 type Enum_SS_CfdLibraryFunction int
 func _swig_getkCfdEnableBitcoin() (_swig_ret Enum_SS_CfdLibraryFunction) {
 	var swig_r Enum_SS_CfdLibraryFunction
-	swig_r = (Enum_SS_CfdLibraryFunction)(C._wrap_kCfdEnableBitcoin_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdLibraryFunction)(C._wrap_kCfdEnableBitcoin_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdEnableBitcoin Enum_SS_CfdLibraryFunction = _swig_getkCfdEnableBitcoin()
 func _swig_getkCfdEnableElements() (_swig_ret Enum_SS_CfdLibraryFunction) {
 	var swig_r Enum_SS_CfdLibraryFunction
-	swig_r = (Enum_SS_CfdLibraryFunction)(C._wrap_kCfdEnableElements_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdLibraryFunction)(C._wrap_kCfdEnableElements_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
@@ -357,55 +361,55 @@ var KCfdEnableElements Enum_SS_CfdLibraryFunction = _swig_getkCfdEnableElements(
 func CfdGetSupportedFunction(arg1 Uint64_t) (_swig_ret int) {
 	var swig_r int
 	_swig_i_0 := arg1.Swigcptr()
-	swig_r = (int)(C._wrap_CfdGetSupportedFunction_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0)))
+	swig_r = (int)(C._wrap_CfdGetSupportedFunction_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func CfdInitialize() (_swig_ret int) {
 	var swig_r int
-	swig_r = (int)(C._wrap_CfdInitialize_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (int)(C._wrap_CfdInitialize_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 func CfdFinalize(arg1 bool) (_swig_ret int) {
 	var swig_r int
 	_swig_i_0 := arg1
-	swig_r = (int)(C._wrap_CfdFinalize_cfdgo_6d81cf84a6c5cb9b(C._Bool(_swig_i_0)))
+	swig_r = (int)(C._wrap_CfdFinalize_cfdgo_3cf2a94eb1b532b7(C._Bool(_swig_i_0)))
 	return swig_r
 }
 
 func CfdCreateHandle(arg1 *uintptr) (_swig_ret int) {
 	var swig_r int
 	_swig_i_0 := arg1
-	swig_r = (int)(C._wrap_CfdCreateHandle_cfdgo_6d81cf84a6c5cb9b(C.swig_voidp(_swig_i_0)))
+	swig_r = (int)(C._wrap_CfdCreateHandle_cfdgo_3cf2a94eb1b532b7(C.swig_voidp(_swig_i_0)))
 	return swig_r
 }
 
 func CfdCreateSimpleHandle(arg1 *uintptr) (_swig_ret int) {
 	var swig_r int
 	_swig_i_0 := arg1
-	swig_r = (int)(C._wrap_CfdCreateSimpleHandle_cfdgo_6d81cf84a6c5cb9b(C.swig_voidp(_swig_i_0)))
+	swig_r = (int)(C._wrap_CfdCreateSimpleHandle_cfdgo_3cf2a94eb1b532b7(C.swig_voidp(_swig_i_0)))
 	return swig_r
 }
 
 func CfdFreeHandle(arg1 uintptr) (_swig_ret int) {
 	var swig_r int
 	_swig_i_0 := arg1
-	swig_r = (int)(C._wrap_CfdFreeHandle_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0)))
+	swig_r = (int)(C._wrap_CfdFreeHandle_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func CfdFreeBuffer(arg1 uintptr) (_swig_ret int) {
 	var swig_r int
 	_swig_i_0 := arg1
-	swig_r = (int)(C._wrap_CfdFreeBuffer_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0)))
+	swig_r = (int)(C._wrap_CfdFreeBuffer_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func CfdGetLastErrorCode(arg1 uintptr) (_swig_ret int) {
 	var swig_r int
 	_swig_i_0 := arg1
-	swig_r = (int)(C._wrap_CfdGetLastErrorCode_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0)))
+	swig_r = (int)(C._wrap_CfdGetLastErrorCode_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
@@ -413,49 +417,49 @@ func CfdGetLastErrorMessage(arg1 uintptr, arg2 *string) (_swig_ret int) {
 	var swig_r int
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r = (int)(C._wrap_CfdGetLastErrorMessage_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), C.swig_voidp(_swig_i_1)))
+	swig_r = (int)(C._wrap_CfdGetLastErrorMessage_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), C.swig_voidp(_swig_i_1)))
 	return swig_r
 }
 
 type Enum_SS_CfdNetworkType int
 func _swig_getkCfdNetworkMainnet() (_swig_ret Enum_SS_CfdNetworkType) {
 	var swig_r Enum_SS_CfdNetworkType
-	swig_r = (Enum_SS_CfdNetworkType)(C._wrap_kCfdNetworkMainnet_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdNetworkType)(C._wrap_kCfdNetworkMainnet_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdNetworkMainnet Enum_SS_CfdNetworkType = _swig_getkCfdNetworkMainnet()
 func _swig_getkCfdNetworkTestnet() (_swig_ret Enum_SS_CfdNetworkType) {
 	var swig_r Enum_SS_CfdNetworkType
-	swig_r = (Enum_SS_CfdNetworkType)(C._wrap_kCfdNetworkTestnet_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdNetworkType)(C._wrap_kCfdNetworkTestnet_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdNetworkTestnet Enum_SS_CfdNetworkType = _swig_getkCfdNetworkTestnet()
 func _swig_getkCfdNetworkRegtest() (_swig_ret Enum_SS_CfdNetworkType) {
 	var swig_r Enum_SS_CfdNetworkType
-	swig_r = (Enum_SS_CfdNetworkType)(C._wrap_kCfdNetworkRegtest_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdNetworkType)(C._wrap_kCfdNetworkRegtest_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdNetworkRegtest Enum_SS_CfdNetworkType = _swig_getkCfdNetworkRegtest()
 func _swig_getkCfdNetworkLiquidv1() (_swig_ret Enum_SS_CfdNetworkType) {
 	var swig_r Enum_SS_CfdNetworkType
-	swig_r = (Enum_SS_CfdNetworkType)(C._wrap_kCfdNetworkLiquidv1_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdNetworkType)(C._wrap_kCfdNetworkLiquidv1_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdNetworkLiquidv1 Enum_SS_CfdNetworkType = _swig_getkCfdNetworkLiquidv1()
 func _swig_getkCfdNetworkElementsRegtest() (_swig_ret Enum_SS_CfdNetworkType) {
 	var swig_r Enum_SS_CfdNetworkType
-	swig_r = (Enum_SS_CfdNetworkType)(C._wrap_kCfdNetworkElementsRegtest_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdNetworkType)(C._wrap_kCfdNetworkElementsRegtest_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdNetworkElementsRegtest Enum_SS_CfdNetworkType = _swig_getkCfdNetworkElementsRegtest()
 func _swig_getkCfdNetworkCustomChain() (_swig_ret Enum_SS_CfdNetworkType) {
 	var swig_r Enum_SS_CfdNetworkType
-	swig_r = (Enum_SS_CfdNetworkType)(C._wrap_kCfdNetworkCustomChain_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdNetworkType)(C._wrap_kCfdNetworkCustomChain_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
@@ -463,42 +467,42 @@ var KCfdNetworkCustomChain Enum_SS_CfdNetworkType = _swig_getkCfdNetworkCustomCh
 type Enum_SS_CfdAddressType int
 func _swig_getkCfdP2shAddress() (_swig_ret Enum_SS_CfdAddressType) {
 	var swig_r Enum_SS_CfdAddressType
-	swig_r = (Enum_SS_CfdAddressType)(C._wrap_kCfdP2shAddress_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdAddressType)(C._wrap_kCfdP2shAddress_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdP2shAddress Enum_SS_CfdAddressType = _swig_getkCfdP2shAddress()
 func _swig_getkCfdP2pkhAddress() (_swig_ret Enum_SS_CfdAddressType) {
 	var swig_r Enum_SS_CfdAddressType
-	swig_r = (Enum_SS_CfdAddressType)(C._wrap_kCfdP2pkhAddress_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdAddressType)(C._wrap_kCfdP2pkhAddress_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdP2pkhAddress Enum_SS_CfdAddressType = _swig_getkCfdP2pkhAddress()
 func _swig_getkCfdP2wshAddress() (_swig_ret Enum_SS_CfdAddressType) {
 	var swig_r Enum_SS_CfdAddressType
-	swig_r = (Enum_SS_CfdAddressType)(C._wrap_kCfdP2wshAddress_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdAddressType)(C._wrap_kCfdP2wshAddress_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdP2wshAddress Enum_SS_CfdAddressType = _swig_getkCfdP2wshAddress()
 func _swig_getkCfdP2wpkhAddress() (_swig_ret Enum_SS_CfdAddressType) {
 	var swig_r Enum_SS_CfdAddressType
-	swig_r = (Enum_SS_CfdAddressType)(C._wrap_kCfdP2wpkhAddress_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdAddressType)(C._wrap_kCfdP2wpkhAddress_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdP2wpkhAddress Enum_SS_CfdAddressType = _swig_getkCfdP2wpkhAddress()
 func _swig_getkCfdP2shP2wshAddress() (_swig_ret Enum_SS_CfdAddressType) {
 	var swig_r Enum_SS_CfdAddressType
-	swig_r = (Enum_SS_CfdAddressType)(C._wrap_kCfdP2shP2wshAddress_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdAddressType)(C._wrap_kCfdP2shP2wshAddress_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdP2shP2wshAddress Enum_SS_CfdAddressType = _swig_getkCfdP2shP2wshAddress()
 func _swig_getkCfdP2shP2wpkhAddress() (_swig_ret Enum_SS_CfdAddressType) {
 	var swig_r Enum_SS_CfdAddressType
-	swig_r = (Enum_SS_CfdAddressType)(C._wrap_kCfdP2shP2wpkhAddress_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdAddressType)(C._wrap_kCfdP2shP2wpkhAddress_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
@@ -506,42 +510,42 @@ var KCfdP2shP2wpkhAddress Enum_SS_CfdAddressType = _swig_getkCfdP2shP2wpkhAddres
 type Enum_SS_CfdHashType int
 func _swig_getkCfdP2sh() (_swig_ret Enum_SS_CfdHashType) {
 	var swig_r Enum_SS_CfdHashType
-	swig_r = (Enum_SS_CfdHashType)(C._wrap_kCfdP2sh_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdHashType)(C._wrap_kCfdP2sh_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdP2sh Enum_SS_CfdHashType = _swig_getkCfdP2sh()
 func _swig_getkCfdP2pkh() (_swig_ret Enum_SS_CfdHashType) {
 	var swig_r Enum_SS_CfdHashType
-	swig_r = (Enum_SS_CfdHashType)(C._wrap_kCfdP2pkh_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdHashType)(C._wrap_kCfdP2pkh_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdP2pkh Enum_SS_CfdHashType = _swig_getkCfdP2pkh()
 func _swig_getkCfdP2wsh() (_swig_ret Enum_SS_CfdHashType) {
 	var swig_r Enum_SS_CfdHashType
-	swig_r = (Enum_SS_CfdHashType)(C._wrap_kCfdP2wsh_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdHashType)(C._wrap_kCfdP2wsh_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdP2wsh Enum_SS_CfdHashType = _swig_getkCfdP2wsh()
 func _swig_getkCfdP2wpkh() (_swig_ret Enum_SS_CfdHashType) {
 	var swig_r Enum_SS_CfdHashType
-	swig_r = (Enum_SS_CfdHashType)(C._wrap_kCfdP2wpkh_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdHashType)(C._wrap_kCfdP2wpkh_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdP2wpkh Enum_SS_CfdHashType = _swig_getkCfdP2wpkh()
 func _swig_getkCfdP2shP2wsh() (_swig_ret Enum_SS_CfdHashType) {
 	var swig_r Enum_SS_CfdHashType
-	swig_r = (Enum_SS_CfdHashType)(C._wrap_kCfdP2shP2wsh_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdHashType)(C._wrap_kCfdP2shP2wsh_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdP2shP2wsh Enum_SS_CfdHashType = _swig_getkCfdP2shP2wsh()
 func _swig_getkCfdP2shP2wpkh() (_swig_ret Enum_SS_CfdHashType) {
 	var swig_r Enum_SS_CfdHashType
-	swig_r = (Enum_SS_CfdHashType)(C._wrap_kCfdP2shP2wpkh_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdHashType)(C._wrap_kCfdP2shP2wpkh_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
@@ -549,21 +553,21 @@ var KCfdP2shP2wpkh Enum_SS_CfdHashType = _swig_getkCfdP2shP2wpkh()
 type Enum_SS_CfdSighashType int
 func _swig_getkCfdSigHashAll() (_swig_ret Enum_SS_CfdSighashType) {
 	var swig_r Enum_SS_CfdSighashType
-	swig_r = (Enum_SS_CfdSighashType)(C._wrap_kCfdSigHashAll_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdSighashType)(C._wrap_kCfdSigHashAll_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdSigHashAll Enum_SS_CfdSighashType = _swig_getkCfdSigHashAll()
 func _swig_getkCfdSigHashNone() (_swig_ret Enum_SS_CfdSighashType) {
 	var swig_r Enum_SS_CfdSighashType
-	swig_r = (Enum_SS_CfdSighashType)(C._wrap_kCfdSigHashNone_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdSighashType)(C._wrap_kCfdSigHashNone_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdSigHashNone Enum_SS_CfdSighashType = _swig_getkCfdSigHashNone()
 func _swig_getkCfdSigHashSingle() (_swig_ret Enum_SS_CfdSighashType) {
 	var swig_r Enum_SS_CfdSighashType
-	swig_r = (Enum_SS_CfdSighashType)(C._wrap_kCfdSigHashSingle_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdSighashType)(C._wrap_kCfdSigHashSingle_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
@@ -571,77 +575,77 @@ var KCfdSigHashSingle Enum_SS_CfdSighashType = _swig_getkCfdSigHashSingle()
 type Enum_SS_CfdDescriptorScriptType int
 func _swig_getkCfdDescriptorScriptNull() (_swig_ret Enum_SS_CfdDescriptorScriptType) {
 	var swig_r Enum_SS_CfdDescriptorScriptType
-	swig_r = (Enum_SS_CfdDescriptorScriptType)(C._wrap_kCfdDescriptorScriptNull_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdDescriptorScriptType)(C._wrap_kCfdDescriptorScriptNull_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdDescriptorScriptNull Enum_SS_CfdDescriptorScriptType = _swig_getkCfdDescriptorScriptNull()
 func _swig_getkCfdDescriptorScriptSh() (_swig_ret Enum_SS_CfdDescriptorScriptType) {
 	var swig_r Enum_SS_CfdDescriptorScriptType
-	swig_r = (Enum_SS_CfdDescriptorScriptType)(C._wrap_kCfdDescriptorScriptSh_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdDescriptorScriptType)(C._wrap_kCfdDescriptorScriptSh_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdDescriptorScriptSh Enum_SS_CfdDescriptorScriptType = _swig_getkCfdDescriptorScriptSh()
 func _swig_getkCfdDescriptorScriptWsh() (_swig_ret Enum_SS_CfdDescriptorScriptType) {
 	var swig_r Enum_SS_CfdDescriptorScriptType
-	swig_r = (Enum_SS_CfdDescriptorScriptType)(C._wrap_kCfdDescriptorScriptWsh_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdDescriptorScriptType)(C._wrap_kCfdDescriptorScriptWsh_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdDescriptorScriptWsh Enum_SS_CfdDescriptorScriptType = _swig_getkCfdDescriptorScriptWsh()
 func _swig_getkCfdDescriptorScriptPk() (_swig_ret Enum_SS_CfdDescriptorScriptType) {
 	var swig_r Enum_SS_CfdDescriptorScriptType
-	swig_r = (Enum_SS_CfdDescriptorScriptType)(C._wrap_kCfdDescriptorScriptPk_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdDescriptorScriptType)(C._wrap_kCfdDescriptorScriptPk_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdDescriptorScriptPk Enum_SS_CfdDescriptorScriptType = _swig_getkCfdDescriptorScriptPk()
 func _swig_getkCfdDescriptorScriptPkh() (_swig_ret Enum_SS_CfdDescriptorScriptType) {
 	var swig_r Enum_SS_CfdDescriptorScriptType
-	swig_r = (Enum_SS_CfdDescriptorScriptType)(C._wrap_kCfdDescriptorScriptPkh_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdDescriptorScriptType)(C._wrap_kCfdDescriptorScriptPkh_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdDescriptorScriptPkh Enum_SS_CfdDescriptorScriptType = _swig_getkCfdDescriptorScriptPkh()
 func _swig_getkCfdDescriptorScriptWpkh() (_swig_ret Enum_SS_CfdDescriptorScriptType) {
 	var swig_r Enum_SS_CfdDescriptorScriptType
-	swig_r = (Enum_SS_CfdDescriptorScriptType)(C._wrap_kCfdDescriptorScriptWpkh_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdDescriptorScriptType)(C._wrap_kCfdDescriptorScriptWpkh_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdDescriptorScriptWpkh Enum_SS_CfdDescriptorScriptType = _swig_getkCfdDescriptorScriptWpkh()
 func _swig_getkCfdDescriptorScriptCombo() (_swig_ret Enum_SS_CfdDescriptorScriptType) {
 	var swig_r Enum_SS_CfdDescriptorScriptType
-	swig_r = (Enum_SS_CfdDescriptorScriptType)(C._wrap_kCfdDescriptorScriptCombo_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdDescriptorScriptType)(C._wrap_kCfdDescriptorScriptCombo_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdDescriptorScriptCombo Enum_SS_CfdDescriptorScriptType = _swig_getkCfdDescriptorScriptCombo()
 func _swig_getkCfdDescriptorScriptMulti() (_swig_ret Enum_SS_CfdDescriptorScriptType) {
 	var swig_r Enum_SS_CfdDescriptorScriptType
-	swig_r = (Enum_SS_CfdDescriptorScriptType)(C._wrap_kCfdDescriptorScriptMulti_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdDescriptorScriptType)(C._wrap_kCfdDescriptorScriptMulti_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdDescriptorScriptMulti Enum_SS_CfdDescriptorScriptType = _swig_getkCfdDescriptorScriptMulti()
 func _swig_getkCfdDescriptorScriptSortedMulti() (_swig_ret Enum_SS_CfdDescriptorScriptType) {
 	var swig_r Enum_SS_CfdDescriptorScriptType
-	swig_r = (Enum_SS_CfdDescriptorScriptType)(C._wrap_kCfdDescriptorScriptSortedMulti_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdDescriptorScriptType)(C._wrap_kCfdDescriptorScriptSortedMulti_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdDescriptorScriptSortedMulti Enum_SS_CfdDescriptorScriptType = _swig_getkCfdDescriptorScriptSortedMulti()
 func _swig_getkCfdDescriptorScriptAddr() (_swig_ret Enum_SS_CfdDescriptorScriptType) {
 	var swig_r Enum_SS_CfdDescriptorScriptType
-	swig_r = (Enum_SS_CfdDescriptorScriptType)(C._wrap_kCfdDescriptorScriptAddr_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdDescriptorScriptType)(C._wrap_kCfdDescriptorScriptAddr_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdDescriptorScriptAddr Enum_SS_CfdDescriptorScriptType = _swig_getkCfdDescriptorScriptAddr()
 func _swig_getkCfdDescriptorScriptRaw() (_swig_ret Enum_SS_CfdDescriptorScriptType) {
 	var swig_r Enum_SS_CfdDescriptorScriptType
-	swig_r = (Enum_SS_CfdDescriptorScriptType)(C._wrap_kCfdDescriptorScriptRaw_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdDescriptorScriptType)(C._wrap_kCfdDescriptorScriptRaw_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
@@ -649,28 +653,28 @@ var KCfdDescriptorScriptRaw Enum_SS_CfdDescriptorScriptType = _swig_getkCfdDescr
 type Enum_SS_CfdDescriptorKeyType int
 func _swig_getkCfdDescriptorKeyNull() (_swig_ret Enum_SS_CfdDescriptorKeyType) {
 	var swig_r Enum_SS_CfdDescriptorKeyType
-	swig_r = (Enum_SS_CfdDescriptorKeyType)(C._wrap_kCfdDescriptorKeyNull_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdDescriptorKeyType)(C._wrap_kCfdDescriptorKeyNull_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdDescriptorKeyNull Enum_SS_CfdDescriptorKeyType = _swig_getkCfdDescriptorKeyNull()
 func _swig_getkCfdDescriptorKeyPublic() (_swig_ret Enum_SS_CfdDescriptorKeyType) {
 	var swig_r Enum_SS_CfdDescriptorKeyType
-	swig_r = (Enum_SS_CfdDescriptorKeyType)(C._wrap_kCfdDescriptorKeyPublic_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdDescriptorKeyType)(C._wrap_kCfdDescriptorKeyPublic_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdDescriptorKeyPublic Enum_SS_CfdDescriptorKeyType = _swig_getkCfdDescriptorKeyPublic()
 func _swig_getkCfdDescriptorKeyBip32() (_swig_ret Enum_SS_CfdDescriptorKeyType) {
 	var swig_r Enum_SS_CfdDescriptorKeyType
-	swig_r = (Enum_SS_CfdDescriptorKeyType)(C._wrap_kCfdDescriptorKeyBip32_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdDescriptorKeyType)(C._wrap_kCfdDescriptorKeyBip32_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdDescriptorKeyBip32 Enum_SS_CfdDescriptorKeyType = _swig_getkCfdDescriptorKeyBip32()
 func _swig_getkCfdDescriptorKeyBip32Priv() (_swig_ret Enum_SS_CfdDescriptorKeyType) {
 	var swig_r Enum_SS_CfdDescriptorKeyType
-	swig_r = (Enum_SS_CfdDescriptorKeyType)(C._wrap_kCfdDescriptorKeyBip32Priv_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdDescriptorKeyType)(C._wrap_kCfdDescriptorKeyBip32Priv_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
@@ -685,7 +689,7 @@ func CfdCreateAddress(arg1 uintptr, arg2 int, arg3 string, arg4 string, arg5 int
 	_swig_i_5 := arg6
 	_swig_i_6 := arg7
 	_swig_i_7 := arg8
-	swig_r = (int)(C._wrap_CfdCreateAddress_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), C.swig_intgo(_swig_i_1), *(*C.swig_type_1)(unsafe.Pointer(&_swig_i_2)), *(*C.swig_type_2)(unsafe.Pointer(&_swig_i_3)), C.swig_intgo(_swig_i_4), C.swig_voidp(_swig_i_5), C.swig_voidp(_swig_i_6), C.swig_voidp(_swig_i_7)))
+	swig_r = (int)(C._wrap_CfdCreateAddress_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), C.swig_intgo(_swig_i_1), *(*C.swig_type_1)(unsafe.Pointer(&_swig_i_2)), *(*C.swig_type_2)(unsafe.Pointer(&_swig_i_3)), C.swig_intgo(_swig_i_4), C.swig_voidp(_swig_i_5), C.swig_voidp(_swig_i_6), C.swig_voidp(_swig_i_7)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg3
 	}
@@ -701,7 +705,7 @@ func CfdInitializeMultisigScript(arg1 uintptr, arg2 int, arg3 int, arg4 *uintptr
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
-	swig_r = (int)(C._wrap_CfdInitializeMultisigScript_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), C.swig_intgo(_swig_i_1), C.swig_intgo(_swig_i_2), C.swig_voidp(_swig_i_3)))
+	swig_r = (int)(C._wrap_CfdInitializeMultisigScript_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), C.swig_intgo(_swig_i_1), C.swig_intgo(_swig_i_2), C.swig_voidp(_swig_i_3)))
 	return swig_r
 }
 
@@ -710,7 +714,7 @@ func CfdAddMultisigScriptData(arg1 uintptr, arg2 uintptr, arg3 string) (_swig_re
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
-	swig_r = (int)(C._wrap_CfdAddMultisigScriptData_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1), *(*C.swig_type_3)(unsafe.Pointer(&_swig_i_2))))
+	swig_r = (int)(C._wrap_CfdAddMultisigScriptData_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1), *(*C.swig_type_3)(unsafe.Pointer(&_swig_i_2))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg3
 	}
@@ -725,7 +729,7 @@ func CfdFinalizeMultisigScript(arg1 uintptr, arg2 uintptr, arg3 Uint32_t, arg4 *
 	_swig_i_3 := arg4
 	_swig_i_4 := arg5
 	_swig_i_5 := arg6
-	swig_r = (int)(C._wrap_CfdFinalizeMultisigScript_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1), C.uintptr_t(_swig_i_2), C.swig_voidp(_swig_i_3), C.swig_voidp(_swig_i_4), C.swig_voidp(_swig_i_5)))
+	swig_r = (int)(C._wrap_CfdFinalizeMultisigScript_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1), C.uintptr_t(_swig_i_2), C.swig_voidp(_swig_i_3), C.swig_voidp(_swig_i_4), C.swig_voidp(_swig_i_5)))
 	return swig_r
 }
 
@@ -733,7 +737,7 @@ func CfdFreeMultisigScriptHandle(arg1 uintptr, arg2 uintptr) (_swig_ret int) {
 	var swig_r int
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r = (int)(C._wrap_CfdFreeMultisigScriptHandle_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1)))
+	swig_r = (int)(C._wrap_CfdFreeMultisigScriptHandle_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1)))
 	return swig_r
 }
 
@@ -745,7 +749,7 @@ func CfdParseDescriptor(arg1 uintptr, arg2 string, arg3 int, arg4 string, arg5 *
 	_swig_i_3 := arg4
 	_swig_i_4 := arg5
 	_swig_i_5 := arg6.Swigcptr()
-	swig_r = (int)(C._wrap_CfdParseDescriptor_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_4)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), *(*C.swig_type_5)(unsafe.Pointer(&_swig_i_3)), C.swig_voidp(_swig_i_4), C.uintptr_t(_swig_i_5)))
+	swig_r = (int)(C._wrap_CfdParseDescriptor_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_4)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), *(*C.swig_type_5)(unsafe.Pointer(&_swig_i_3)), C.swig_voidp(_swig_i_4), C.uintptr_t(_swig_i_5)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -773,7 +777,7 @@ func CfdGetDescriptorData(arg1 uintptr, arg2 uintptr, arg3 Uint32_t, arg4 Uint32
 	_swig_i_13 := arg14
 	_swig_i_14 := arg15
 	_swig_i_15 := arg16.Swigcptr()
-	swig_r = (int)(C._wrap_CfdGetDescriptorData_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1), C.uintptr_t(_swig_i_2), C.uintptr_t(_swig_i_3), C.uintptr_t(_swig_i_4), C.swig_voidp(_swig_i_5), C.swig_voidp(_swig_i_6), C.swig_voidp(_swig_i_7), C.swig_voidp(_swig_i_8), C.swig_voidp(_swig_i_9), C.swig_voidp(_swig_i_10), C.swig_voidp(_swig_i_11), C.swig_voidp(_swig_i_12), C.swig_voidp(_swig_i_13), C.swig_voidp(_swig_i_14), C.uintptr_t(_swig_i_15)))
+	swig_r = (int)(C._wrap_CfdGetDescriptorData_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1), C.uintptr_t(_swig_i_2), C.uintptr_t(_swig_i_3), C.uintptr_t(_swig_i_4), C.swig_voidp(_swig_i_5), C.swig_voidp(_swig_i_6), C.swig_voidp(_swig_i_7), C.swig_voidp(_swig_i_8), C.swig_voidp(_swig_i_9), C.swig_voidp(_swig_i_10), C.swig_voidp(_swig_i_11), C.swig_voidp(_swig_i_12), C.swig_voidp(_swig_i_13), C.swig_voidp(_swig_i_14), C.uintptr_t(_swig_i_15)))
 	return swig_r
 }
 
@@ -786,7 +790,7 @@ func CfdGetDescriptorMultisigKey(arg1 uintptr, arg2 uintptr, arg3 Uint32_t, arg4
 	_swig_i_4 := arg5
 	_swig_i_5 := arg6
 	_swig_i_6 := arg7
-	swig_r = (int)(C._wrap_CfdGetDescriptorMultisigKey_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1), C.uintptr_t(_swig_i_2), C.swig_voidp(_swig_i_3), C.swig_voidp(_swig_i_4), C.swig_voidp(_swig_i_5), C.swig_voidp(_swig_i_6)))
+	swig_r = (int)(C._wrap_CfdGetDescriptorMultisigKey_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1), C.uintptr_t(_swig_i_2), C.swig_voidp(_swig_i_3), C.swig_voidp(_swig_i_4), C.swig_voidp(_swig_i_5), C.swig_voidp(_swig_i_6)))
 	return swig_r
 }
 
@@ -794,7 +798,7 @@ func CfdFreeDescriptorHandle(arg1 uintptr, arg2 uintptr) (_swig_ret int) {
 	var swig_r int
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r = (int)(C._wrap_CfdFreeDescriptorHandle_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1)))
+	swig_r = (int)(C._wrap_CfdFreeDescriptorHandle_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1)))
 	return swig_r
 }
 
@@ -806,7 +810,7 @@ func CfdGetAddressesFromMultisig(arg1 uintptr, arg2 string, arg3 int, arg4 int, 
 	_swig_i_3 := arg4
 	_swig_i_4 := arg5
 	_swig_i_5 := arg6.Swigcptr()
-	swig_r = (int)(C._wrap_CfdGetAddressesFromMultisig_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_6)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.swig_intgo(_swig_i_3), C.swig_voidp(_swig_i_4), C.uintptr_t(_swig_i_5)))
+	swig_r = (int)(C._wrap_CfdGetAddressesFromMultisig_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_6)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.swig_intgo(_swig_i_3), C.swig_voidp(_swig_i_4), C.uintptr_t(_swig_i_5)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -820,7 +824,7 @@ func CfdGetAddressFromMultisigKey(arg1 uintptr, arg2 uintptr, arg3 Uint32_t, arg
 	_swig_i_2 := arg3.Swigcptr()
 	_swig_i_3 := arg4
 	_swig_i_4 := arg5
-	swig_r = (int)(C._wrap_CfdGetAddressFromMultisigKey_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1), C.uintptr_t(_swig_i_2), C.swig_voidp(_swig_i_3), C.swig_voidp(_swig_i_4)))
+	swig_r = (int)(C._wrap_CfdGetAddressFromMultisigKey_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1), C.uintptr_t(_swig_i_2), C.swig_voidp(_swig_i_3), C.swig_voidp(_swig_i_4)))
 	return swig_r
 }
 
@@ -828,7 +832,20 @@ func CfdFreeAddressesMultisigHandle(arg1 uintptr, arg2 uintptr) (_swig_ret int) 
 	var swig_r int
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r = (int)(C._wrap_CfdFreeAddressesMultisigHandle_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1)))
+	swig_r = (int)(C._wrap_CfdFreeAddressesMultisigHandle_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1)))
+	return swig_r
+}
+
+func CfdGetAddressFromLockingScript(arg1 uintptr, arg2 string, arg3 int, arg4 *string) (_swig_ret int) {
+	var swig_r int
+	_swig_i_0 := arg1
+	_swig_i_1 := arg2
+	_swig_i_2 := arg3
+	_swig_i_3 := arg4
+	swig_r = (int)(C._wrap_CfdGetAddressFromLockingScript_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_7)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.swig_voidp(_swig_i_3)))
+	if Swig_escape_always_false {
+		Swig_escape_val = arg2
+	}
 	return swig_r
 }
 
@@ -838,7 +855,7 @@ func CfdCreateConfidentialAddress(arg1 uintptr, arg2 string, arg3 string, arg4 *
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
-	swig_r = (int)(C._wrap_CfdCreateConfidentialAddress_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_7)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_8)(unsafe.Pointer(&_swig_i_2)), C.swig_voidp(_swig_i_3)))
+	swig_r = (int)(C._wrap_CfdCreateConfidentialAddress_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_8)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_9)(unsafe.Pointer(&_swig_i_2)), C.swig_voidp(_swig_i_3)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -855,7 +872,7 @@ func CfdParseConfidentialAddress(arg1 uintptr, arg2 string, arg3 *string, arg4 *
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
 	_swig_i_4 := arg5
-	swig_r = (int)(C._wrap_CfdParseConfidentialAddress_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_9)(unsafe.Pointer(&_swig_i_1)), C.swig_voidp(_swig_i_2), C.swig_voidp(_swig_i_3), C.swig_voidp(_swig_i_4)))
+	swig_r = (int)(C._wrap_CfdParseConfidentialAddress_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_10)(unsafe.Pointer(&_swig_i_1)), C.swig_voidp(_swig_i_2), C.swig_voidp(_swig_i_3), C.swig_voidp(_swig_i_4)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -868,7 +885,7 @@ func CfdInitializeConfidentialTx(arg1 uintptr, arg2 Uint32_t, arg3 Uint32_t, arg
 	_swig_i_1 := arg2.Swigcptr()
 	_swig_i_2 := arg3.Swigcptr()
 	_swig_i_3 := arg4
-	swig_r = (int)(C._wrap_CfdInitializeConfidentialTx_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1), C.uintptr_t(_swig_i_2), C.swig_voidp(_swig_i_3)))
+	swig_r = (int)(C._wrap_CfdInitializeConfidentialTx_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1), C.uintptr_t(_swig_i_2), C.swig_voidp(_swig_i_3)))
 	return swig_r
 }
 
@@ -880,7 +897,7 @@ func CfdAddConfidentialTxIn(arg1 uintptr, arg2 string, arg3 string, arg4 Uint32_
 	_swig_i_3 := arg4.Swigcptr()
 	_swig_i_4 := arg5.Swigcptr()
 	_swig_i_5 := arg6
-	swig_r = (int)(C._wrap_CfdAddConfidentialTxIn_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_10)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_11)(unsafe.Pointer(&_swig_i_2)), C.uintptr_t(_swig_i_3), C.uintptr_t(_swig_i_4), C.swig_voidp(_swig_i_5)))
+	swig_r = (int)(C._wrap_CfdAddConfidentialTxIn_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_11)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_12)(unsafe.Pointer(&_swig_i_2)), C.uintptr_t(_swig_i_3), C.uintptr_t(_swig_i_4), C.swig_voidp(_swig_i_5)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -901,7 +918,7 @@ func CfdAddConfidentialTxOut(arg1 uintptr, arg2 string, arg3 string, arg4 Int64_
 	_swig_i_6 := arg7
 	_swig_i_7 := arg8
 	_swig_i_8 := arg9
-	swig_r = (int)(C._wrap_CfdAddConfidentialTxOut_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_12)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_13)(unsafe.Pointer(&_swig_i_2)), C.uintptr_t(_swig_i_3), *(*C.swig_type_14)(unsafe.Pointer(&_swig_i_4)), *(*C.swig_type_15)(unsafe.Pointer(&_swig_i_5)), *(*C.swig_type_16)(unsafe.Pointer(&_swig_i_6)), *(*C.swig_type_17)(unsafe.Pointer(&_swig_i_7)), C.swig_voidp(_swig_i_8)))
+	swig_r = (int)(C._wrap_CfdAddConfidentialTxOut_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_13)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_14)(unsafe.Pointer(&_swig_i_2)), C.uintptr_t(_swig_i_3), *(*C.swig_type_15)(unsafe.Pointer(&_swig_i_4)), *(*C.swig_type_16)(unsafe.Pointer(&_swig_i_5)), *(*C.swig_type_17)(unsafe.Pointer(&_swig_i_6)), *(*C.swig_type_18)(unsafe.Pointer(&_swig_i_7)), C.swig_voidp(_swig_i_8)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -935,7 +952,7 @@ func CfdUpdateConfidentialTxOut(arg1 uintptr, arg2 string, arg3 Uint32_t, arg4 s
 	_swig_i_7 := arg8
 	_swig_i_8 := arg9
 	_swig_i_9 := arg10
-	swig_r = (int)(C._wrap_CfdUpdateConfidentialTxOut_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_18)(unsafe.Pointer(&_swig_i_1)), C.uintptr_t(_swig_i_2), *(*C.swig_type_19)(unsafe.Pointer(&_swig_i_3)), C.uintptr_t(_swig_i_4), *(*C.swig_type_20)(unsafe.Pointer(&_swig_i_5)), *(*C.swig_type_21)(unsafe.Pointer(&_swig_i_6)), *(*C.swig_type_22)(unsafe.Pointer(&_swig_i_7)), *(*C.swig_type_23)(unsafe.Pointer(&_swig_i_8)), C.swig_voidp(_swig_i_9)))
+	swig_r = (int)(C._wrap_CfdUpdateConfidentialTxOut_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_19)(unsafe.Pointer(&_swig_i_1)), C.uintptr_t(_swig_i_2), *(*C.swig_type_20)(unsafe.Pointer(&_swig_i_3)), C.uintptr_t(_swig_i_4), *(*C.swig_type_21)(unsafe.Pointer(&_swig_i_5)), *(*C.swig_type_22)(unsafe.Pointer(&_swig_i_6)), *(*C.swig_type_23)(unsafe.Pointer(&_swig_i_7)), *(*C.swig_type_24)(unsafe.Pointer(&_swig_i_8)), C.swig_voidp(_swig_i_9)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -957,6 +974,25 @@ func CfdUpdateConfidentialTxOut(arg1 uintptr, arg2 string, arg3 Uint32_t, arg4 s
 	return swig_r
 }
 
+func CfdGetConfidentialTxInfo(arg1 uintptr, arg2 string, arg3 *string, arg4 *string, arg5 *string, arg6 Uint32_t, arg7 Uint32_t, arg8 Uint32_t, arg9 Uint32_t, arg10 Uint32_t) (_swig_ret int) {
+	var swig_r int
+	_swig_i_0 := arg1
+	_swig_i_1 := arg2
+	_swig_i_2 := arg3
+	_swig_i_3 := arg4
+	_swig_i_4 := arg5
+	_swig_i_5 := arg6.Swigcptr()
+	_swig_i_6 := arg7.Swigcptr()
+	_swig_i_7 := arg8.Swigcptr()
+	_swig_i_8 := arg9.Swigcptr()
+	_swig_i_9 := arg10.Swigcptr()
+	swig_r = (int)(C._wrap_CfdGetConfidentialTxInfo_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_25)(unsafe.Pointer(&_swig_i_1)), C.swig_voidp(_swig_i_2), C.swig_voidp(_swig_i_3), C.swig_voidp(_swig_i_4), C.uintptr_t(_swig_i_5), C.uintptr_t(_swig_i_6), C.uintptr_t(_swig_i_7), C.uintptr_t(_swig_i_8), C.uintptr_t(_swig_i_9)))
+	if Swig_escape_always_false {
+		Swig_escape_val = arg2
+	}
+	return swig_r
+}
+
 func CfdGetConfidentialTxIn(arg1 uintptr, arg2 string, arg3 Uint32_t, arg4 *string, arg5 Uint32_t, arg6 Uint32_t, arg7 *string) (_swig_ret int) {
 	var swig_r int
 	_swig_i_0 := arg1
@@ -966,7 +1002,7 @@ func CfdGetConfidentialTxIn(arg1 uintptr, arg2 string, arg3 Uint32_t, arg4 *stri
 	_swig_i_4 := arg5.Swigcptr()
 	_swig_i_5 := arg6.Swigcptr()
 	_swig_i_6 := arg7
-	swig_r = (int)(C._wrap_CfdGetConfidentialTxIn_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_24)(unsafe.Pointer(&_swig_i_1)), C.uintptr_t(_swig_i_2), C.swig_voidp(_swig_i_3), C.uintptr_t(_swig_i_4), C.uintptr_t(_swig_i_5), C.swig_voidp(_swig_i_6)))
+	swig_r = (int)(C._wrap_CfdGetConfidentialTxIn_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_26)(unsafe.Pointer(&_swig_i_1)), C.uintptr_t(_swig_i_2), C.swig_voidp(_swig_i_3), C.uintptr_t(_swig_i_4), C.uintptr_t(_swig_i_5), C.swig_voidp(_swig_i_6)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -980,7 +1016,7 @@ func CfdGetConfidentialTxInWitness(arg1 uintptr, arg2 string, arg3 Uint32_t, arg
 	_swig_i_2 := arg3.Swigcptr()
 	_swig_i_3 := arg4.Swigcptr()
 	_swig_i_4 := arg5
-	swig_r = (int)(C._wrap_CfdGetConfidentialTxInWitness_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_25)(unsafe.Pointer(&_swig_i_1)), C.uintptr_t(_swig_i_2), C.uintptr_t(_swig_i_3), C.swig_voidp(_swig_i_4)))
+	swig_r = (int)(C._wrap_CfdGetConfidentialTxInWitness_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_27)(unsafe.Pointer(&_swig_i_1)), C.uintptr_t(_swig_i_2), C.uintptr_t(_swig_i_3), C.swig_voidp(_swig_i_4)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -1000,7 +1036,7 @@ func CfdGetTxInIssuanceInfo(arg1 uintptr, arg2 string, arg3 Uint32_t, arg4 *stri
 	_swig_i_8 := arg9
 	_swig_i_9 := arg10
 	_swig_i_10 := arg11
-	swig_r = (int)(C._wrap_CfdGetTxInIssuanceInfo_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_26)(unsafe.Pointer(&_swig_i_1)), C.uintptr_t(_swig_i_2), C.swig_voidp(_swig_i_3), C.swig_voidp(_swig_i_4), C.uintptr_t(_swig_i_5), C.swig_voidp(_swig_i_6), C.uintptr_t(_swig_i_7), C.swig_voidp(_swig_i_8), C.swig_voidp(_swig_i_9), C.swig_voidp(_swig_i_10)))
+	swig_r = (int)(C._wrap_CfdGetTxInIssuanceInfo_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_28)(unsafe.Pointer(&_swig_i_1)), C.uintptr_t(_swig_i_2), C.swig_voidp(_swig_i_3), C.swig_voidp(_swig_i_4), C.uintptr_t(_swig_i_5), C.swig_voidp(_swig_i_6), C.uintptr_t(_swig_i_7), C.swig_voidp(_swig_i_8), C.swig_voidp(_swig_i_9), C.swig_voidp(_swig_i_10)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -1019,7 +1055,7 @@ func CfdGetConfidentialTxOut(arg1 uintptr, arg2 string, arg3 Uint32_t, arg4 *str
 	_swig_i_7 := arg8
 	_swig_i_8 := arg9
 	_swig_i_9 := arg10
-	swig_r = (int)(C._wrap_CfdGetConfidentialTxOut_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_27)(unsafe.Pointer(&_swig_i_1)), C.uintptr_t(_swig_i_2), C.swig_voidp(_swig_i_3), C.uintptr_t(_swig_i_4), C.swig_voidp(_swig_i_5), C.swig_voidp(_swig_i_6), C.swig_voidp(_swig_i_7), C.swig_voidp(_swig_i_8), C.swig_voidp(_swig_i_9)))
+	swig_r = (int)(C._wrap_CfdGetConfidentialTxOut_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_29)(unsafe.Pointer(&_swig_i_1)), C.uintptr_t(_swig_i_2), C.swig_voidp(_swig_i_3), C.uintptr_t(_swig_i_4), C.swig_voidp(_swig_i_5), C.swig_voidp(_swig_i_6), C.swig_voidp(_swig_i_7), C.swig_voidp(_swig_i_8), C.swig_voidp(_swig_i_9)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -1031,7 +1067,7 @@ func CfdGetConfidentialTxInCount(arg1 uintptr, arg2 string, arg3 Uint32_t) (_swi
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3.Swigcptr()
-	swig_r = (int)(C._wrap_CfdGetConfidentialTxInCount_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_28)(unsafe.Pointer(&_swig_i_1)), C.uintptr_t(_swig_i_2)))
+	swig_r = (int)(C._wrap_CfdGetConfidentialTxInCount_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_30)(unsafe.Pointer(&_swig_i_1)), C.uintptr_t(_swig_i_2)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -1044,7 +1080,7 @@ func CfdGetConfidentialTxInWitnessCount(arg1 uintptr, arg2 string, arg3 Uint32_t
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3.Swigcptr()
 	_swig_i_3 := arg4.Swigcptr()
-	swig_r = (int)(C._wrap_CfdGetConfidentialTxInWitnessCount_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_29)(unsafe.Pointer(&_swig_i_1)), C.uintptr_t(_swig_i_2), C.uintptr_t(_swig_i_3)))
+	swig_r = (int)(C._wrap_CfdGetConfidentialTxInWitnessCount_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_31)(unsafe.Pointer(&_swig_i_1)), C.uintptr_t(_swig_i_2), C.uintptr_t(_swig_i_3)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -1056,7 +1092,7 @@ func CfdGetConfidentialTxOutCount(arg1 uintptr, arg2 string, arg3 Uint32_t) (_sw
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3.Swigcptr()
-	swig_r = (int)(C._wrap_CfdGetConfidentialTxOutCount_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_30)(unsafe.Pointer(&_swig_i_1)), C.uintptr_t(_swig_i_2)))
+	swig_r = (int)(C._wrap_CfdGetConfidentialTxOutCount_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_32)(unsafe.Pointer(&_swig_i_1)), C.uintptr_t(_swig_i_2)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -1076,7 +1112,7 @@ func CfdSetRawReissueAsset(arg1 uintptr, arg2 string, arg3 string, arg4 Uint32_t
 	_swig_i_8 := arg9
 	_swig_i_9 := arg10
 	_swig_i_10 := arg11
-	swig_r = (int)(C._wrap_CfdSetRawReissueAsset_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_31)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_32)(unsafe.Pointer(&_swig_i_2)), C.uintptr_t(_swig_i_3), C.uintptr_t(_swig_i_4), *(*C.swig_type_33)(unsafe.Pointer(&_swig_i_5)), *(*C.swig_type_34)(unsafe.Pointer(&_swig_i_6)), *(*C.swig_type_35)(unsafe.Pointer(&_swig_i_7)), *(*C.swig_type_36)(unsafe.Pointer(&_swig_i_8)), C.swig_voidp(_swig_i_9), C.swig_voidp(_swig_i_10)))
+	swig_r = (int)(C._wrap_CfdSetRawReissueAsset_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_33)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_34)(unsafe.Pointer(&_swig_i_2)), C.uintptr_t(_swig_i_3), C.uintptr_t(_swig_i_4), *(*C.swig_type_35)(unsafe.Pointer(&_swig_i_5)), *(*C.swig_type_36)(unsafe.Pointer(&_swig_i_6)), *(*C.swig_type_37)(unsafe.Pointer(&_swig_i_7)), *(*C.swig_type_38)(unsafe.Pointer(&_swig_i_8)), C.swig_voidp(_swig_i_9), C.swig_voidp(_swig_i_10)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -1105,7 +1141,7 @@ func CfdGetIssuanceBlindingKey(arg1 uintptr, arg2 string, arg3 string, arg4 Uint
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4.Swigcptr()
 	_swig_i_4 := arg5
-	swig_r = (int)(C._wrap_CfdGetIssuanceBlindingKey_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_37)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_38)(unsafe.Pointer(&_swig_i_2)), C.uintptr_t(_swig_i_3), C.swig_voidp(_swig_i_4)))
+	swig_r = (int)(C._wrap_CfdGetIssuanceBlindingKey_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_39)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_40)(unsafe.Pointer(&_swig_i_2)), C.uintptr_t(_swig_i_3), C.swig_voidp(_swig_i_4)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -1119,7 +1155,7 @@ func CfdInitializeBlindTx(arg1 uintptr, arg2 *uintptr) (_swig_ret int) {
 	var swig_r int
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r = (int)(C._wrap_CfdInitializeBlindTx_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), C.swig_voidp(_swig_i_1)))
+	swig_r = (int)(C._wrap_CfdInitializeBlindTx_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), C.swig_voidp(_swig_i_1)))
 	return swig_r
 }
 
@@ -1135,7 +1171,7 @@ func CfdAddBlindTxInData(arg1 uintptr, arg2 uintptr, arg3 string, arg4 Uint32_t,
 	_swig_i_7 := arg8.Swigcptr()
 	_swig_i_8 := arg9
 	_swig_i_9 := arg10
-	swig_r = (int)(C._wrap_CfdAddBlindTxInData_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1), *(*C.swig_type_39)(unsafe.Pointer(&_swig_i_2)), C.uintptr_t(_swig_i_3), *(*C.swig_type_40)(unsafe.Pointer(&_swig_i_4)), *(*C.swig_type_41)(unsafe.Pointer(&_swig_i_5)), *(*C.swig_type_42)(unsafe.Pointer(&_swig_i_6)), C.uintptr_t(_swig_i_7), *(*C.swig_type_43)(unsafe.Pointer(&_swig_i_8)), *(*C.swig_type_44)(unsafe.Pointer(&_swig_i_9))))
+	swig_r = (int)(C._wrap_CfdAddBlindTxInData_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1), *(*C.swig_type_41)(unsafe.Pointer(&_swig_i_2)), C.uintptr_t(_swig_i_3), *(*C.swig_type_42)(unsafe.Pointer(&_swig_i_4)), *(*C.swig_type_43)(unsafe.Pointer(&_swig_i_5)), *(*C.swig_type_44)(unsafe.Pointer(&_swig_i_6)), C.uintptr_t(_swig_i_7), *(*C.swig_type_45)(unsafe.Pointer(&_swig_i_8)), *(*C.swig_type_46)(unsafe.Pointer(&_swig_i_9))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg3
 	}
@@ -1163,7 +1199,7 @@ func CfdAddBlindTxOutData(arg1 uintptr, arg2 uintptr, arg3 Uint32_t, arg4 string
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3.Swigcptr()
 	_swig_i_3 := arg4
-	swig_r = (int)(C._wrap_CfdAddBlindTxOutData_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1), C.uintptr_t(_swig_i_2), *(*C.swig_type_45)(unsafe.Pointer(&_swig_i_3))))
+	swig_r = (int)(C._wrap_CfdAddBlindTxOutData_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1), C.uintptr_t(_swig_i_2), *(*C.swig_type_47)(unsafe.Pointer(&_swig_i_3))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg4
 	}
@@ -1176,7 +1212,7 @@ func CfdFinalizeBlindTx(arg1 uintptr, arg2 uintptr, arg3 string, arg4 *string) (
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
-	swig_r = (int)(C._wrap_CfdFinalizeBlindTx_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1), *(*C.swig_type_46)(unsafe.Pointer(&_swig_i_2)), C.swig_voidp(_swig_i_3)))
+	swig_r = (int)(C._wrap_CfdFinalizeBlindTx_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1), *(*C.swig_type_48)(unsafe.Pointer(&_swig_i_2)), C.swig_voidp(_swig_i_3)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg3
 	}
@@ -1187,7 +1223,7 @@ func CfdFreeBlindHandle(arg1 uintptr, arg2 uintptr) (_swig_ret int) {
 	var swig_r int
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r = (int)(C._wrap_CfdFreeBlindHandle_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1)))
+	swig_r = (int)(C._wrap_CfdFreeBlindHandle_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1)))
 	return swig_r
 }
 
@@ -1201,7 +1237,7 @@ func CfdAddConfidentialTxSign(arg1 uintptr, arg2 string, arg3 string, arg4 Uint3
 	_swig_i_5 := arg6
 	_swig_i_6 := arg7
 	_swig_i_7 := arg8
-	swig_r = (int)(C._wrap_CfdAddConfidentialTxSign_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_47)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_48)(unsafe.Pointer(&_swig_i_2)), C.uintptr_t(_swig_i_3), C._Bool(_swig_i_4), *(*C.swig_type_49)(unsafe.Pointer(&_swig_i_5)), C._Bool(_swig_i_6), C.swig_voidp(_swig_i_7)))
+	swig_r = (int)(C._wrap_CfdAddConfidentialTxSign_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_49)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_50)(unsafe.Pointer(&_swig_i_2)), C.uintptr_t(_swig_i_3), C._Bool(_swig_i_4), *(*C.swig_type_51)(unsafe.Pointer(&_swig_i_5)), C._Bool(_swig_i_6), C.swig_voidp(_swig_i_7)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -1226,7 +1262,7 @@ func CfdAddConfidentialTxDerSign(arg1 uintptr, arg2 string, arg3 string, arg4 Ui
 	_swig_i_7 := arg8
 	_swig_i_8 := arg9
 	_swig_i_9 := arg10
-	swig_r = (int)(C._wrap_CfdAddConfidentialTxDerSign_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_50)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_51)(unsafe.Pointer(&_swig_i_2)), C.uintptr_t(_swig_i_3), C._Bool(_swig_i_4), *(*C.swig_type_52)(unsafe.Pointer(&_swig_i_5)), C.swig_intgo(_swig_i_6), C._Bool(_swig_i_7), C._Bool(_swig_i_8), C.swig_voidp(_swig_i_9)))
+	swig_r = (int)(C._wrap_CfdAddConfidentialTxDerSign_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_52)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_53)(unsafe.Pointer(&_swig_i_2)), C.uintptr_t(_swig_i_3), C._Bool(_swig_i_4), *(*C.swig_type_54)(unsafe.Pointer(&_swig_i_5)), C.swig_intgo(_swig_i_6), C._Bool(_swig_i_7), C._Bool(_swig_i_8), C.swig_voidp(_swig_i_9)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -1251,7 +1287,7 @@ func CfdFinalizeElementsMultisigSign(arg1 uintptr, arg2 uintptr, arg3 string, ar
 	_swig_i_7 := arg8
 	_swig_i_8 := arg9
 	_swig_i_9 := arg10
-	swig_r = (int)(C._wrap_CfdFinalizeElementsMultisigSign_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1), *(*C.swig_type_53)(unsafe.Pointer(&_swig_i_2)), *(*C.swig_type_54)(unsafe.Pointer(&_swig_i_3)), C.uintptr_t(_swig_i_4), C.swig_intgo(_swig_i_5), *(*C.swig_type_55)(unsafe.Pointer(&_swig_i_6)), *(*C.swig_type_56)(unsafe.Pointer(&_swig_i_7)), C._Bool(_swig_i_8), C.swig_voidp(_swig_i_9)))
+	swig_r = (int)(C._wrap_CfdFinalizeElementsMultisigSign_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1), *(*C.swig_type_55)(unsafe.Pointer(&_swig_i_2)), *(*C.swig_type_56)(unsafe.Pointer(&_swig_i_3)), C.uintptr_t(_swig_i_4), C.swig_intgo(_swig_i_5), *(*C.swig_type_57)(unsafe.Pointer(&_swig_i_6)), *(*C.swig_type_58)(unsafe.Pointer(&_swig_i_7)), C._Bool(_swig_i_8), C.swig_voidp(_swig_i_9)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg3
 	}
@@ -1281,7 +1317,7 @@ func CfdCreateConfidentialSighash(arg1 uintptr, arg2 string, arg3 string, arg4 U
 	_swig_i_9 := arg10
 	_swig_i_10 := arg11
 	_swig_i_11 := arg12
-	swig_r = (int)(C._wrap_CfdCreateConfidentialSighash_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_57)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_58)(unsafe.Pointer(&_swig_i_2)), C.uintptr_t(_swig_i_3), C.swig_intgo(_swig_i_4), *(*C.swig_type_59)(unsafe.Pointer(&_swig_i_5)), *(*C.swig_type_60)(unsafe.Pointer(&_swig_i_6)), C.uintptr_t(_swig_i_7), *(*C.swig_type_61)(unsafe.Pointer(&_swig_i_8)), C.swig_intgo(_swig_i_9), C._Bool(_swig_i_10), C.swig_voidp(_swig_i_11)))
+	swig_r = (int)(C._wrap_CfdCreateConfidentialSighash_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_59)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_60)(unsafe.Pointer(&_swig_i_2)), C.uintptr_t(_swig_i_3), C.swig_intgo(_swig_i_4), *(*C.swig_type_61)(unsafe.Pointer(&_swig_i_5)), *(*C.swig_type_62)(unsafe.Pointer(&_swig_i_6)), C.uintptr_t(_swig_i_7), *(*C.swig_type_63)(unsafe.Pointer(&_swig_i_8)), C.swig_intgo(_swig_i_9), C._Bool(_swig_i_10), C.swig_voidp(_swig_i_11)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -1310,7 +1346,7 @@ func CfdUnblindTxOut(arg1 uintptr, arg2 string, arg3 Uint32_t, arg4 string, arg5
 	_swig_i_5 := arg6.Swigcptr()
 	_swig_i_6 := arg7
 	_swig_i_7 := arg8
-	swig_r = (int)(C._wrap_CfdUnblindTxOut_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_62)(unsafe.Pointer(&_swig_i_1)), C.uintptr_t(_swig_i_2), *(*C.swig_type_63)(unsafe.Pointer(&_swig_i_3)), C.swig_voidp(_swig_i_4), C.uintptr_t(_swig_i_5), C.swig_voidp(_swig_i_6), C.swig_voidp(_swig_i_7)))
+	swig_r = (int)(C._wrap_CfdUnblindTxOut_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_64)(unsafe.Pointer(&_swig_i_1)), C.uintptr_t(_swig_i_2), *(*C.swig_type_65)(unsafe.Pointer(&_swig_i_3)), C.swig_voidp(_swig_i_4), C.uintptr_t(_swig_i_5), C.swig_voidp(_swig_i_6), C.swig_voidp(_swig_i_7)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -1335,7 +1371,7 @@ func CfdUnblindIssuance(arg1 uintptr, arg2 string, arg3 Uint32_t, arg4 string, a
 	_swig_i_10 := arg11.Swigcptr()
 	_swig_i_11 := arg12
 	_swig_i_12 := arg13
-	swig_r = (int)(C._wrap_CfdUnblindIssuance_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_64)(unsafe.Pointer(&_swig_i_1)), C.uintptr_t(_swig_i_2), *(*C.swig_type_65)(unsafe.Pointer(&_swig_i_3)), *(*C.swig_type_66)(unsafe.Pointer(&_swig_i_4)), C.swig_voidp(_swig_i_5), C.uintptr_t(_swig_i_6), C.swig_voidp(_swig_i_7), C.swig_voidp(_swig_i_8), C.swig_voidp(_swig_i_9), C.uintptr_t(_swig_i_10), C.swig_voidp(_swig_i_11), C.swig_voidp(_swig_i_12)))
+	swig_r = (int)(C._wrap_CfdUnblindIssuance_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_66)(unsafe.Pointer(&_swig_i_1)), C.uintptr_t(_swig_i_2), *(*C.swig_type_67)(unsafe.Pointer(&_swig_i_3)), *(*C.swig_type_68)(unsafe.Pointer(&_swig_i_4)), C.swig_voidp(_swig_i_5), C.uintptr_t(_swig_i_6), C.swig_voidp(_swig_i_7), C.swig_voidp(_swig_i_8), C.swig_voidp(_swig_i_9), C.uintptr_t(_swig_i_10), C.swig_voidp(_swig_i_11), C.swig_voidp(_swig_i_12)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -1351,14 +1387,14 @@ func CfdUnblindIssuance(arg1 uintptr, arg2 string, arg3 Uint32_t, arg4 string, a
 type Enum_SS_CfdExtKeyType int
 func _swig_getkCfdExtPrivkey() (_swig_ret Enum_SS_CfdExtKeyType) {
 	var swig_r Enum_SS_CfdExtKeyType
-	swig_r = (Enum_SS_CfdExtKeyType)(C._wrap_kCfdExtPrivkey_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdExtKeyType)(C._wrap_kCfdExtPrivkey_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdExtPrivkey Enum_SS_CfdExtKeyType = _swig_getkCfdExtPrivkey()
 func _swig_getkCfdExtPubkey() (_swig_ret Enum_SS_CfdExtKeyType) {
 	var swig_r Enum_SS_CfdExtKeyType
-	swig_r = (Enum_SS_CfdExtKeyType)(C._wrap_kCfdExtPubkey_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdExtKeyType)(C._wrap_kCfdExtPubkey_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
@@ -1372,7 +1408,7 @@ func CfdCalculateEcSignature(arg1 uintptr, arg2 string, arg3 string, arg4 string
 	_swig_i_4 := arg5
 	_swig_i_5 := arg6
 	_swig_i_6 := arg7
-	swig_r = (int)(C._wrap_CfdCalculateEcSignature_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_67)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_68)(unsafe.Pointer(&_swig_i_2)), *(*C.swig_type_69)(unsafe.Pointer(&_swig_i_3)), C.swig_intgo(_swig_i_4), C._Bool(_swig_i_5), C.swig_voidp(_swig_i_6)))
+	swig_r = (int)(C._wrap_CfdCalculateEcSignature_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_69)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_70)(unsafe.Pointer(&_swig_i_2)), *(*C.swig_type_71)(unsafe.Pointer(&_swig_i_3)), C.swig_intgo(_swig_i_4), C._Bool(_swig_i_5), C.swig_voidp(_swig_i_6)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -1393,7 +1429,7 @@ func CfdCreateKeyPair(arg1 uintptr, arg2 bool, arg3 int, arg4 *string, arg5 *str
 	_swig_i_3 := arg4
 	_swig_i_4 := arg5
 	_swig_i_5 := arg6
-	swig_r = (int)(C._wrap_CfdCreateKeyPair_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), C._Bool(_swig_i_1), C.swig_intgo(_swig_i_2), C.swig_voidp(_swig_i_3), C.swig_voidp(_swig_i_4), C.swig_voidp(_swig_i_5)))
+	swig_r = (int)(C._wrap_CfdCreateKeyPair_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), C._Bool(_swig_i_1), C.swig_intgo(_swig_i_2), C.swig_voidp(_swig_i_3), C.swig_voidp(_swig_i_4), C.swig_voidp(_swig_i_5)))
 	return swig_r
 }
 
@@ -1403,7 +1439,7 @@ func CfdGetPrivkeyFromWif(arg1 uintptr, arg2 string, arg3 int, arg4 *string) (_s
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
-	swig_r = (int)(C._wrap_CfdGetPrivkeyFromWif_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_70)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.swig_voidp(_swig_i_3)))
+	swig_r = (int)(C._wrap_CfdGetPrivkeyFromWif_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_72)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.swig_voidp(_swig_i_3)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -1417,7 +1453,7 @@ func CfdGetPubkeyFromPrivkey(arg1 uintptr, arg2 string, arg3 string, arg4 bool, 
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
 	_swig_i_4 := arg5
-	swig_r = (int)(C._wrap_CfdGetPubkeyFromPrivkey_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_71)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_72)(unsafe.Pointer(&_swig_i_2)), C._Bool(_swig_i_3), C.swig_voidp(_swig_i_4)))
+	swig_r = (int)(C._wrap_CfdGetPubkeyFromPrivkey_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_73)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_74)(unsafe.Pointer(&_swig_i_2)), C._Bool(_swig_i_3), C.swig_voidp(_swig_i_4)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -1434,7 +1470,7 @@ func CfdCreateExtkeyFromSeed(arg1 uintptr, arg2 string, arg3 int, arg4 int, arg5
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
 	_swig_i_4 := arg5
-	swig_r = (int)(C._wrap_CfdCreateExtkeyFromSeed_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_73)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.swig_intgo(_swig_i_3), C.swig_voidp(_swig_i_4)))
+	swig_r = (int)(C._wrap_CfdCreateExtkeyFromSeed_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_75)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.swig_intgo(_swig_i_3), C.swig_voidp(_swig_i_4)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -1449,7 +1485,7 @@ func CfdCreateExtkeyFromParentPath(arg1 uintptr, arg2 string, arg3 string, arg4 
 	_swig_i_3 := arg4
 	_swig_i_4 := arg5
 	_swig_i_5 := arg6
-	swig_r = (int)(C._wrap_CfdCreateExtkeyFromParentPath_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_74)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_75)(unsafe.Pointer(&_swig_i_2)), C.swig_intgo(_swig_i_3), C.swig_intgo(_swig_i_4), C.swig_voidp(_swig_i_5)))
+	swig_r = (int)(C._wrap_CfdCreateExtkeyFromParentPath_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_76)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_77)(unsafe.Pointer(&_swig_i_2)), C.swig_intgo(_swig_i_3), C.swig_intgo(_swig_i_4), C.swig_voidp(_swig_i_5)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -1465,7 +1501,7 @@ func CfdCreateExtPubkey(arg1 uintptr, arg2 string, arg3 int, arg4 *string) (_swi
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
-	swig_r = (int)(C._wrap_CfdCreateExtPubkey_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_76)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.swig_voidp(_swig_i_3)))
+	swig_r = (int)(C._wrap_CfdCreateExtPubkey_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_78)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.swig_voidp(_swig_i_3)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -1479,7 +1515,7 @@ func CfdGetPrivkeyFromExtkey(arg1 uintptr, arg2 string, arg3 int, arg4 *string, 
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
 	_swig_i_4 := arg5
-	swig_r = (int)(C._wrap_CfdGetPrivkeyFromExtkey_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_77)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.swig_voidp(_swig_i_3), C.swig_voidp(_swig_i_4)))
+	swig_r = (int)(C._wrap_CfdGetPrivkeyFromExtkey_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_79)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.swig_voidp(_swig_i_3), C.swig_voidp(_swig_i_4)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -1492,7 +1528,7 @@ func CfdGetPubkeyFromExtkey(arg1 uintptr, arg2 string, arg3 int, arg4 *string) (
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
-	swig_r = (int)(C._wrap_CfdGetPubkeyFromExtkey_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_78)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.swig_voidp(_swig_i_3)))
+	swig_r = (int)(C._wrap_CfdGetPubkeyFromExtkey_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_80)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.swig_voidp(_swig_i_3)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -1505,7 +1541,7 @@ func CfdParseScript(arg1 uintptr, arg2 string, arg3 *uintptr, arg4 Uint32_t) (_s
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4.Swigcptr()
-	swig_r = (int)(C._wrap_CfdParseScript_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), *(*C.swig_type_79)(unsafe.Pointer(&_swig_i_1)), C.swig_voidp(_swig_i_2), C.uintptr_t(_swig_i_3)))
+	swig_r = (int)(C._wrap_CfdParseScript_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), *(*C.swig_type_81)(unsafe.Pointer(&_swig_i_1)), C.swig_voidp(_swig_i_2), C.uintptr_t(_swig_i_3)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -1518,7 +1554,7 @@ func CfdGetScriptItem(arg1 uintptr, arg2 uintptr, arg3 Uint32_t, arg4 *string) (
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3.Swigcptr()
 	_swig_i_3 := arg4
-	swig_r = (int)(C._wrap_CfdGetScriptItem_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1), C.uintptr_t(_swig_i_2), C.swig_voidp(_swig_i_3)))
+	swig_r = (int)(C._wrap_CfdGetScriptItem_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1), C.uintptr_t(_swig_i_2), C.swig_voidp(_swig_i_3)))
 	return swig_r
 }
 
@@ -1526,21 +1562,21 @@ func CfdFreeScriptItemHandle(arg1 uintptr, arg2 uintptr) (_swig_ret int) {
 	var swig_r int
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r = (int)(C._wrap_CfdFreeScriptItemHandle_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1)))
+	swig_r = (int)(C._wrap_CfdFreeScriptItemHandle_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1)))
 	return swig_r
 }
 
 type Enum_SS_CfdSequenceLockTime int
 func _swig_getkCfdSequenceLockTimeDisable() (_swig_ret Enum_SS_CfdSequenceLockTime) {
 	var swig_r Enum_SS_CfdSequenceLockTime
-	swig_r = (Enum_SS_CfdSequenceLockTime)(C._wrap_kCfdSequenceLockTimeDisable_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdSequenceLockTime)(C._wrap_kCfdSequenceLockTimeDisable_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
 var KCfdSequenceLockTimeDisable Enum_SS_CfdSequenceLockTime = _swig_getkCfdSequenceLockTimeDisable()
 func _swig_getkCfdSequenceLockTimeEnableMax() (_swig_ret Enum_SS_CfdSequenceLockTime) {
 	var swig_r Enum_SS_CfdSequenceLockTime
-	swig_r = (Enum_SS_CfdSequenceLockTime)(C._wrap_kCfdSequenceLockTimeEnableMax_cfdgo_6d81cf84a6c5cb9b())
+	swig_r = (Enum_SS_CfdSequenceLockTime)(C._wrap_kCfdSequenceLockTimeEnableMax_cfdgo_3cf2a94eb1b532b7())
 	return swig_r
 }
 
@@ -1549,7 +1585,7 @@ func CfdInitializeMultisigSign(arg1 uintptr, arg2 *uintptr) (_swig_ret int) {
 	var swig_r int
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r = (int)(C._wrap_CfdInitializeMultisigSign_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), C.swig_voidp(_swig_i_1)))
+	swig_r = (int)(C._wrap_CfdInitializeMultisigSign_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), C.swig_voidp(_swig_i_1)))
 	return swig_r
 }
 
@@ -1559,7 +1595,7 @@ func CfdAddMultisigSignData(arg1 uintptr, arg2 uintptr, arg3 string, arg4 string
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
-	swig_r = (int)(C._wrap_CfdAddMultisigSignData_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1), *(*C.swig_type_80)(unsafe.Pointer(&_swig_i_2)), *(*C.swig_type_81)(unsafe.Pointer(&_swig_i_3))))
+	swig_r = (int)(C._wrap_CfdAddMultisigSignData_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1), *(*C.swig_type_82)(unsafe.Pointer(&_swig_i_2)), *(*C.swig_type_83)(unsafe.Pointer(&_swig_i_3))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg3
 	}
@@ -1577,7 +1613,7 @@ func CfdAddMultisigSignDataToDer(arg1 uintptr, arg2 uintptr, arg3 string, arg4 i
 	_swig_i_3 := arg4
 	_swig_i_4 := arg5
 	_swig_i_5 := arg6
-	swig_r = (int)(C._wrap_CfdAddMultisigSignDataToDer_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1), *(*C.swig_type_82)(unsafe.Pointer(&_swig_i_2)), C.swig_intgo(_swig_i_3), C._Bool(_swig_i_4), *(*C.swig_type_83)(unsafe.Pointer(&_swig_i_5))))
+	swig_r = (int)(C._wrap_CfdAddMultisigSignDataToDer_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1), *(*C.swig_type_84)(unsafe.Pointer(&_swig_i_2)), C.swig_intgo(_swig_i_3), C._Bool(_swig_i_4), *(*C.swig_type_85)(unsafe.Pointer(&_swig_i_5))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg3
 	}
@@ -1591,7 +1627,7 @@ func CfdFreeMultisigSignHandle(arg1 uintptr, arg2 uintptr) (_swig_ret int) {
 	var swig_r int
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r = (int)(C._wrap_CfdFreeMultisigSignHandle_cfdgo_6d81cf84a6c5cb9b(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1)))
+	swig_r = (int)(C._wrap_CfdFreeMultisigSignHandle_cfdgo_3cf2a94eb1b532b7(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1)))
 	return swig_r
 }
 
@@ -1893,6 +1929,21 @@ func CfdGoGetAddressesFromMultisig(handle uintptr, redeemScript string, networkT
 }
 
 /**
+ * Get address from locking script.
+ * param: handle         cfd handle
+ * param: lockingScript  locking script
+ * param: networkType    network type
+ * param: hashType       hash type (p2sh, p2wsh, etc...)
+ * return: address       address
+ * return: err           error
+ */
+func CfdGoGetAddressFromLockingScript(handle uintptr, lockingScript string, networkType int) (address string, err error) {
+	ret := CfdGetAddressFromLockingScript(handle, lockingScript, networkType, &address)
+	err = convertCfdError(ret, handle)
+	return address, err
+}
+
+/**
  * Get initialized confidential transaction.
  * param: handle        cfd handle
  * param: version       transaction version
@@ -1966,6 +2017,38 @@ func CfdGoUpdateConfidentialTxOut(handle uintptr, txHex string, index uint32, as
 	ret := CfdUpdateConfidentialTxOut(handle, txHex, indexPtr, asset, satoshiPtr, valueCommitment, address, directLockingScript, nonce, &outputTxHex)
 	err = convertCfdError(ret, handle)
 	return outputTxHex, err
+}
+
+/**
+ * TxData data struct.
+ */
+type CfdTxData struct {
+	Txid string
+	Wtxid string
+	WitHash string
+	Size uint32
+	Vsize uint32
+	Weight uint32
+	Version uint32
+	LockTime uint32
+}
+
+/**
+ * Get confidential transaction data.
+ * param: handle        cfd handle
+ * param: txHex         transaction hex
+ * return: data         transaction data
+ * return: err          error
+ */
+func CfdGoGetConfidentialTxData(handle uintptr, txHex string) (data CfdTxData, err error) {
+	sizePtr := SwigcptrUint32_t(uintptr(unsafe.Pointer(&data.Size)))
+	vsizePtr := SwigcptrUint32_t(uintptr(unsafe.Pointer(&data.Vsize)))
+	weightPtr := SwigcptrUint32_t(uintptr(unsafe.Pointer(&data.Weight)))
+	versionPtr := SwigcptrUint32_t(uintptr(unsafe.Pointer(&data.Version)))
+	locktimePtr := SwigcptrUint32_t(uintptr(unsafe.Pointer(&data.LockTime)))
+	ret := CfdGetConfidentialTxInfo(handle, txHex, &data.Txid, &data.Wtxid, &data.WitHash, sizePtr, vsizePtr, weightPtr, versionPtr, locktimePtr)
+	err = convertCfdError(ret, handle)
+	return data, err
 }
 
 /**

--- a/cfdgo_test.go
+++ b/cfdgo_test.go
@@ -174,6 +174,36 @@ func TestCfdGoGetAddressesFromMultisig(t *testing.T) {
 	fmt.Print("TestCfdGoGetAddressesFromMultisig test done.\n")
 }
 
+func TestCfdGoGetAddressFromLockingScript(t *testing.T) {
+	handle, err := CfdGoCreateHandle()
+	assert.NoError(t, err)
+
+	networkType := (int)(KCfdNetworkLiquidv1)
+	lockingScript := "76a91449a011f97ba520dab063f309bad59daeb30de10188ac"
+	address, err := CfdGoGetAddressFromLockingScript(handle, lockingScript, networkType)
+	assert.NoError(t, err)
+	assert.Equal(t, "Q3ygD4rfNT2npj341csKqxcgDkBMwyD5Z6", address)
+
+	lockingScript = "a914f1b3a2cc24eba8a741f963b309a7686f3bb6bfb487"
+	address, err = CfdGoGetAddressFromLockingScript(handle, lockingScript, networkType)
+	assert.NoError(t, err)
+	assert.Equal(t, "H5DXSnmWy4WuUU7Yr8bvtLa5nXgukNc3Z6", address)
+
+	lockingScript = "0014925d4028880bd0c9d68fbc7fc7dfee976698629c"
+	address, err = CfdGoGetAddressFromLockingScript(handle, lockingScript, networkType)
+	assert.NoError(t, err)
+	assert.Equal(t, "ex1qjfw5q2ygp0gvn450h3lu0hlwjanfsc5uh0r5gq", address)
+
+	lockingScript = "002087cb0bc07de5b5befd7565b2c63fb1681efd8af7bd85a3f0f98a529a5c50a437"
+	address, err = CfdGoGetAddressFromLockingScript(handle, lockingScript, networkType)
+	assert.NoError(t, err)
+	assert.Equal(t, "ex1qsl9shsrauk6malt4vkevv0a3dq00mzhhhkz68u8e3fff5hzs5sms77zw4m", address)
+
+	err = CfdGoFreeHandle(handle)
+	assert.NoError(t, err)
+	fmt.Print("TestCfdGoGetAddressesFromMultisig test done.\n")
+}
+
 func TestCfdGoParseDescriptor(t *testing.T) {
 	handle, err := CfdGoCreateHandle()
 	assert.NoError(t, err)
@@ -380,6 +410,19 @@ func TestCfdGetTransaction(t *testing.T) {
 	assert.Equal(t, uint32(4), count)
 
 	if err == nil {
+		txData, err := CfdGoGetConfidentialTxData(handle, txHex)
+		assert.NoError(t, err)
+		assert.Equal(t, "cf7783b2b1de646e35186df988a219a17f0317b5c3f3c47fa4ab2d7463ea3992", txData.Txid)
+		assert.Equal(t, "cf7783b2b1de646e35186df988a219a17f0317b5c3f3c47fa4ab2d7463ea3992", txData.Wtxid)
+		assert.Equal(t, "938e3a9b5bac410e812d08db74c4ef2bc58d1ed99d94b637cab0ac2e9eb59df8", txData.WitHash)
+		assert.Equal(t, uint32(512), txData.Size)
+		assert.Equal(t, uint32(512), txData.Vsize)
+		assert.Equal(t, uint32(2048), txData.Weight)
+		assert.Equal(t, uint32(2), txData.Version)
+		assert.Equal(t, uint32(0), txData.LockTime)
+	}
+
+	if err == nil {
 		txid, vout, sequence, scriptSig, err := CfdGoGetConfidentialTxIn(handle, txHex, uint32(1))
 		assert.NoError(t, err)
 		assert.Equal(t, "57a15002d066ce52573d674df925c9bc0f1164849420705f2cfad8a68111230f", txid)
@@ -531,6 +574,19 @@ func TestCfdBlindTransaction(t *testing.T) {
 
 	err2 := CfdGoFreeBlindHandle(handle, blindHandle) // release
 	assert.NoError(t, err2)
+
+	if err == nil {
+		txData, err := CfdGoGetConfidentialTxData(handle, txHex)
+		assert.NoError(t, err)
+		assert.Equal(t, 64, len(txData.Txid))
+		assert.Equal(t, 64, len(txData.Wtxid))
+		assert.Equal(t, 64, len(txData.WitHash))
+		assert.Equal(t, uint32(12589), txData.Size)
+		assert.Equal(t, uint32(3604), txData.Vsize)
+		assert.Equal(t, uint32(14413), txData.Weight)
+		assert.Equal(t, uint32(2), txData.Version)
+		assert.Equal(t, uint32(0), txData.LockTime)
+	}
 
 	// unblind test
 	if err == nil {

--- a/local_resource/external_project_local_setting.config
+++ b/local_resource/external_project_local_setting.config
@@ -1,4 +1,4 @@
-CFD_TARGET_VERSION=features/sprint32
+CFD_TARGET_VERSION=feature/elements_api_20191210
 CFDCORE_TARGET_VERSION=features/sprint32
 LIBWALLY_TARGET_VERSION=cmake_build
 CFD_TARGET_URL=https://github.com/cryptogarageinc/cfd.git

--- a/local_resource/external_project_local_setting.config
+++ b/local_resource/external_project_local_setting.config
@@ -1,4 +1,4 @@
-CFD_TARGET_VERSION=feature/elements_api_20191210
+CFD_TARGET_VERSION=features/sprint32
 CFDCORE_TARGET_VERSION=features/sprint32
 LIBWALLY_TARGET_VERSION=cmake_build
 CFD_TARGET_URL=https://github.com/cryptogarageinc/cfd.git

--- a/swig.i
+++ b/swig.i
@@ -327,6 +327,21 @@ func CfdGoGetAddressesFromMultisig(handle uintptr, redeemScript string, networkT
 }
 
 /**
+ * Get address from locking script.
+ * param: handle         cfd handle
+ * param: lockingScript  locking script
+ * param: networkType    network type
+ * param: hashType       hash type (p2sh, p2wsh, etc...)
+ * return: address       address
+ * return: err           error
+ */
+func CfdGoGetAddressFromLockingScript(handle uintptr, lockingScript string, networkType int) (address string, err error) {
+	ret := CfdGetAddressFromLockingScript(handle, lockingScript, networkType, &address)
+	err = convertCfdError(ret, handle)
+	return address, err
+}
+
+/**
  * Get initialized confidential transaction.
  * param: handle        cfd handle
  * param: version       transaction version
@@ -400,6 +415,38 @@ func CfdGoUpdateConfidentialTxOut(handle uintptr, txHex string, index uint32, as
 	ret := CfdUpdateConfidentialTxOut(handle, txHex, indexPtr, asset, satoshiPtr, valueCommitment, address, directLockingScript, nonce, &outputTxHex)
 	err = convertCfdError(ret, handle)
 	return outputTxHex, err
+}
+
+/**
+ * TxData data struct.
+ */
+type CfdTxData struct {
+	Txid string
+	Wtxid string
+	WitHash string
+	Size uint32
+	Vsize uint32
+	Weight uint32
+	Version uint32
+	LockTime uint32
+}
+
+/**
+ * Get confidential transaction data.
+ * param: handle        cfd handle
+ * param: txHex         transaction hex
+ * return: data         transaction data
+ * return: err          error
+ */
+func CfdGoGetConfidentialTxData(handle uintptr, txHex string) (data CfdTxData, err error) {
+	sizePtr := SwigcptrUint32_t(uintptr(unsafe.Pointer(&data.Size)))
+	vsizePtr := SwigcptrUint32_t(uintptr(unsafe.Pointer(&data.Vsize)))
+	weightPtr := SwigcptrUint32_t(uintptr(unsafe.Pointer(&data.Weight)))
+	versionPtr := SwigcptrUint32_t(uintptr(unsafe.Pointer(&data.Version)))
+	locktimePtr := SwigcptrUint32_t(uintptr(unsafe.Pointer(&data.LockTime)))
+	ret := CfdGetConfidentialTxInfo(handle, txHex, &data.Txid, &data.Wtxid, &data.WitHash, sizePtr, vsizePtr, weightPtr, versionPtr, locktimePtr)
+	err = convertCfdError(ret, handle)
+	return data, err
 }
 
 /**


### PR DESCRIPTION
## 関連Issue

<!--
このPRが、ZenHubのどのIssueに紐づいているかを記載する
  - ZenHubのURL
-->
- https://app.zenhub.com/workspaces/cfd-5cdbe88f0f84751dcd8fd7ab/issues/cryptogarageinc/btclib-sandbox/1043
- https://app.zenhub.com/workspaces/cfd-5cdbe88f0f84751dcd8fd7ab/issues/cryptogarageinc/btclib-sandbox/1044

## 概要

<!--
- 追加機能の概要を記載
- 前提が共有されていない場合は、  
  なぜこの変更をして、  
  どう解決されるのかも併せて記載する

- 必要であれば、以下のような詳細についても記載する
  - 以下の観点で、レビューアーにわかるように技術的な変更点の概要を記載
    - 何をどう変更したか
    - どういった手法を採用したか  
      （e.g. パス探索については、幅優先探索を採用した）
    - 外部システムとのI/F変更
    - など
-->

- 1043: cfd-api, capi追加
  - cfd: AddressFactoryにGetAddressByLockingScript 追加
  - c-api: CfdGetConfidentialTxInfo, CfdGetAddressFromLockingScript を追加
- 1044: cfd-go
  - CfdGoGetConfidentialTxInfo, CfdGoGetAddressFromLockingScript を追加
  - 乱数不具合修正
    - cfd-core: Windows mingwで乱数生成の不具合があったため、ifdefで処理差し替え。
    - https://cpprefjp.github.io/reference/random/random_device.html

## 使い方

<!-- 
- PRの動作確認方法
  - 動作確認が必要なタスクについては、必要なコマンドなどを記載
  - 必要なければ、無記載で良い
-->

```bash
npm run check_all
```

## 今回保留した項目とTODO

<!--
- 箇条書きで保留した項目があれば、記載
  - 保留項目が直近の対応が必要な場合、対応チケットを作成して記載

記載例
- 〇〇の計算ロジックの本実装 #0000
-->

- Witness txのチェックはcfd-goのみに記載。(blind tx)

## 確認項目

**PRを出した人**
<!-- PRを出す前後で確認する項目 -->

- [x] チェックスクリプトでチェックを実施した <!-- npm run check -->
- [x] 正常にビルドできた
- [x] 関連チケットに実績をつけた
- [x] ZenHubでPRとIssueを関連付けた
- [x] ZenHubのIssueを `Review/QA` Pipelineに移した

**レビューする人**
<!-- レビューをする前後で確認する項目 -->
- [ ] 関連チケットにレビュー実績をつけた

## 備考

<!--
- 実装に関する悩み（AにするかBにするか迷ったがAにしたや、こうしたかったけどできなかったなど）があれば記載
-->
- 関連のあるレポジトリ
  - cfd <- cfd-go : 追加API参照のため、ブランチ記載一時変更
    - cfd-coreの修正は依存が無いため、ブランチ記載変更なし