### PR TITLE
fix: calc rangeproof on estimate fee

### DIFF
--- a/cfdgo_test.go
+++ b/cfdgo_test.go
@@ -1182,8 +1182,9 @@ func TestCfdBlindTransaction3(t *testing.T) {
 	assert.Equal(t, int64(7), inputFee)
 	totalFee, txFee, inputFee, err = CfdGoEstimateFee(txHex2, inputs, feeOption)
 	assert.NoError(t, err)
-	assert.Equal(t, int64(99), totalFee)
-	assert.Equal(t, int64(92), txFee)
+	// TODO: When not set or blinding, calculation assuming the maximum size
+	assert.Equal(t, int64(130), totalFee)
+	assert.Equal(t, int64(123), txFee)
 	assert.Equal(t, int64(7), inputFee)
 	// feeOption.MinimumBits = 52
 	//assert.Equal(t, int64(129), totalFee)

--- a/local_resource/external_project_local_setting.config
+++ b/local_resource/external_project_local_setting.config
@@ -1,6 +1,6 @@
-CFDGO_VERSION=0.1.39
-CFD_TARGET_VERSION=refs/tags/v0.1.20
-CFDCORE_TARGET_VERSION=refs/tags/v0.1.17
+CFDGO_VERSION=0.1.40
+CFD_TARGET_VERSION=refs/tags/v0.1.21
+CFDCORE_TARGET_VERSION=refs/tags/v0.1.18
 LIBWALLY_TARGET_VERSION=refs/tags/cfd-0.0.6
 CFD_TARGET_URL=cryptogarageinc/cfd.git
 CFDCORE_TARGET_URL=cryptogarageinc/cfd-core.git


### PR DESCRIPTION
## Linked Issue

<!--
for linked ZenHub Issue or other repository issue.
  - ZenHub's issue URL
  - other repository's issue URL
-->

## Overview

- fix: calc rangeproof on estimate fee
  - When calculating the size of rangeproof when calculating the fee, the amount was set as a dummy.
  - As a result, when the amount of money was large, the rangeproof became larger than when the fee was calculated, and the fee value calculated as a result was a small value.

## How to use

<!-- 
- How to check the operation
  - For tasks that require operation confirmation, enter the required commands, etc.
  - If not needed, leave blank
-->

```bash
```

## Items reserved this time, or TODO

<!--
- If not needed, leave blank
-->

## Check list

** Person who issued **
- [x] checked script <!-- npm run check -->
- [x] build successed
- [ ] Linked PullRequest and Issue

** Reviewer **
- [ ] (if necessary) Record the review results of related tickets.

## Memo

<!--
- Explain any considerations or considerations.
-->
