### PR TITLE
fix: remove macos 10.15 asset, update test target go version

### DIFF
--- a/.github/workflows/check_pre-merge_develop.yml
+++ b/.github/workflows/check_pre-merge_develop.yml
@@ -22,20 +22,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12, macos-11, macos-10.15, windows-2022, windows-2019, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
-        go-version: [1.16.x, 1.17.x, 1.18.x]
+        os: [macos-12, macos-11, windows-2022, windows-2019, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
+        go-version: ['~1.17', '~1.18', '~1.19']
         exclude:
           - os: windows-2019
-            go-version: 1.17.x
-          - os: macos-10.15
-            go-version: 1.17.x
+            go-version: '~1.17'
 
     steps:
     - name: setup go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name:  cmake-generate-windows
       if: runner.os == 'Windows'
       run: cmake -S . -B build -G "MSYS Makefiles" -DENABLE_SHARED=on -DENABLE_TESTS=off -DTARGET_RPATH="/usr/local/lib;/usr/local/lib64;./build/Release"

--- a/.github/workflows/check_pre-merge_master.yml
+++ b/.github/workflows/check_pre-merge_master.yml
@@ -24,20 +24,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12, macos-11, macos-10.15, windows-2022, windows-2019, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
-        go-version: [1.16.x, 1.17.x, 1.18.x]
+        os: [macos-12, macos-11, windows-2022, windows-2019, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
+        go-version: ['~1.17', '~1.18', '~1.19']
         exclude:
           - os: windows-2019
-            go-version: 1.17.x
-          - os: macos-10.15
-            go-version: 1.17.x
+            go-version: '~1.17'
 
     steps:
     - name: setup go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name:  cmake-generate-windows
       if: runner.os == 'Windows'
       run: cmake -S . -B build -G "MSYS Makefiles" -DENABLE_SHARED=on -DENABLE_TESTS=off -DTARGET_RPATH="/usr/local/lib;/usr/local/lib64;./build/Release"

--- a/.github/workflows/check_pre-merge_sprint.yml
+++ b/.github/workflows/check_pre-merge_sprint.yml
@@ -22,15 +22,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12, macos-11, macos-10.15, windows-2022, windows-2019, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
-        go-version: [1.16.x, 1.17.x, 1.18.x]
+        os: [macos-12, macos-11, windows-2022, windows-2019, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
+        go-version: ['~1.17', '~1.18', '~1.19']
 
     steps:
     - name: setup go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name:  cmake-generate-windows
       if: runner.os == 'Windows'
       run: cmake -S . -B build -G "MSYS Makefiles" -DENABLE_SHARED=on -DENABLE_TESTS=off -DTARGET_RPATH="/usr/local/lib;/usr/local/lib64;./build/Release"

--- a/.github/workflows/create_release-and-upload.yml
+++ b/.github/workflows/create_release-and-upload.yml
@@ -271,13 +271,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode: ['10.3', '11.7', '12.4', '12.5.1', '13.2.1', '13.3.1']
+        xcode: ['12.4', '12.5.1', '13.2.1', '13.3.1', '13.4.1']
         shared: [on, off]
         include:
-          - xcode: '10.3'
-            os: macos-10.15
-          - xcode: '11.7'
-            os: macos-10.15
           - xcode: '12.4'
             os: macos-10.15
           - xcode: '12.5.1'
@@ -285,6 +281,8 @@ jobs:
           - xcode: '13.2.1'
             os: macos-11
           - xcode: '13.3.1'
+            os: macos-12
+          - xcode: '13.4.1'
             os: macos-12
           - shared: on
             suffix: ''


### PR DESCRIPTION
## Linked Issue

<!--
for linked ZenHub Issue or other repository issue.
  - ZenHub's issue URL
  - other repository's issue URL
-->

## Overview

- fix: remove macos 10.15 asset
- test: update target go version (add 1.19, remove 1.16)

## How to use

<!-- 
- How to check the operation
  - For tasks that require operation confirmation, enter the required commands, etc.
  - If not needed, leave blank
-->

```bash
```

## Items reserved this time, or TODO

<!--
- If not needed, leave blank
-->

## Check list

** Person who issued **
- [x] checked script <!-- npm run check -->
- [x] build successed
- [ ] Linked PullRequest and Issue

** Reviewer **
- [ ] (if necessary) Record the review results of related tickets.

## Memo

<!--
- Explain any considerations or considerations.
-->
